### PR TITLE
feat: @easybread/data-mapper package

### DIFF
--- a/packages/common/src/lib/inerfaces/index.ts
+++ b/packages/common/src/lib/inerfaces/index.ts
@@ -1,3 +1,6 @@
 export type { NotString } from './not-string.interface';
 export type { ObjectProperties } from './object-properties.interface';
 export type { ObjectPropertyValueType } from './object-property-value.interface';
+export type { InterfaceToType } from './interface-to-type';
+export type { IsLiteral } from './is-literal';
+export type { KeysByValueType } from './keys-by-value-type';

--- a/packages/common/src/lib/inerfaces/interface-to-type.ts
+++ b/packages/common/src/lib/inerfaces/interface-to-type.ts
@@ -1,0 +1,6 @@
+/**
+ * Converts an interface to a type.
+ *
+ * @template T interface to convert
+ */
+export type InterfaceToType<T extends object> = { [K in keyof T]: T[K] };

--- a/packages/common/src/lib/inerfaces/is-literal.ts
+++ b/packages/common/src/lib/inerfaces/is-literal.ts
@@ -1,0 +1,18 @@
+/**
+ * Checks if a type is a literal type.
+ *
+ * @template T type to check
+ */
+export type IsLiteral<T> = T extends string | number | boolean
+  ? string extends T
+    ? false
+    : number extends T
+    ? false
+    : boolean extends T
+    ? false
+    : bigint extends T
+    ? false
+    : symbol extends T
+    ? false
+    : true
+  : false;

--- a/packages/common/src/lib/inerfaces/keys-by-value-type.ts
+++ b/packages/common/src/lib/inerfaces/keys-by-value-type.ts
@@ -1,0 +1,13 @@
+/**
+ * Extracts a union of keys from an object
+ * whose values are of a certain type.
+ *
+ * @template TObj object to extract keys from
+ * @template TValueType value type to extract keys for
+ */
+export type KeysByValueType<
+  TObj extends Record<string, unknown>,
+  TValueType
+> = {
+  [K in keyof TObj]: TObj[K] extends TValueType ? K : never;
+}[keyof TObj];

--- a/packages/data-mapper/.eslintrc.json
+++ b/packages/data-mapper/.eslintrc.json
@@ -1,0 +1,30 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.json"],
+      "parser": "jsonc-eslint-parser",
+      "rules": {
+        "@nx/dependency-checks": [
+          "error",
+          {
+            "ignoredFiles": ["{projectRoot}/rollup.config.{js,ts,mjs,mts}"]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/data-mapper/.swcrc
+++ b/packages/data-mapper/.swcrc
@@ -1,0 +1,29 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    },
+    "keepClassNames": true,
+    "externalHelpers": true,
+    "loose": true
+  },
+  "module": {
+    "type": "es6"
+  },
+  "sourceMaps": "inline",
+  "exclude": [
+    "jest.config.ts",
+    ".*\\.spec.tsx?$",
+    ".*\\.test.tsx?$",
+    "./src/jest-setup.ts$",
+    "./**/jest-setup.ts$",
+    ".*.js$"
+  ]
+}

--- a/packages/data-mapper/README.md
+++ b/packages/data-mapper/README.md
@@ -1,0 +1,11 @@
+# data-mapper
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build data-mapper` to build the library.
+
+## Running unit tests
+
+Run `nx test data-mapper` to execute the unit tests via [Jest](https://jestjs.io).

--- a/packages/data-mapper/jest.config.ts
+++ b/packages/data-mapper/jest.config.ts
@@ -1,0 +1,30 @@
+/* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/nx-api/jest/documents/overview#global-setupteardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
+export default {
+  displayName: 'data-mapper',
+  preset: '../../jest.preset.js',
+  transform: {
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: '',
+  coverageDirectory: '../../coverage/packages/data-mapper',
+};

--- a/packages/data-mapper/package.json
+++ b/packages/data-mapper/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@easybread/data-mapper",
+  "version": "0.0.1",
+  "dependencies": {
+    "@easybread/common": "0.0.1"
+  },
+  "main": "./index.cjs",
+  "module": "./index.js"
+}

--- a/packages/data-mapper/project.json
+++ b/packages/data-mapper/project.json
@@ -1,0 +1,22 @@
+{
+  "name": "data-mapper",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/data-mapper/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "generatorOptions": {
+        "packageRoot": "dist/{projectRoot}",
+        "currentVersionResolver": "git-tag"
+      }
+    }
+  },
+  "tags": [],
+  "targets": {
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    }
+  }
+}

--- a/packages/data-mapper/rollup.config.js
+++ b/packages/data-mapper/rollup.config.js
@@ -1,0 +1,17 @@
+const { withNx } = require('@nx/rollup/with-nx');
+
+module.exports = withNx(
+  {
+    main: './src/index.ts',
+    outputPath: '../../dist/packages/data-mapper',
+    tsConfig: './tsconfig.lib.json',
+    compiler: 'swc',
+    format: ['cjs', 'esm'],
+    assets: [{ input: '.', output: '.', glob: '*.md' }],
+  },
+  {
+    // Provide additional rollup configuration here. See: https://rollupjs.org/configuration-options
+    // e.g.
+    // output: { sourcemap: true },
+  }
+);

--- a/packages/data-mapper/src/__tests__/bread.data-mapper.spec.ts
+++ b/packages/data-mapper/src/__tests__/bread.data-mapper.spec.ts
@@ -1,0 +1,212 @@
+import { BreadDataMapper } from '..';
+import { Readable } from 'node:stream';
+
+it(`should work with plain objects with primitive types`, async () => {
+  type Input = {
+    a: string;
+    b: number;
+    c: boolean;
+    d: bigint;
+    e: symbol;
+  };
+
+  type Output = {
+    str: string;
+    num: number;
+    bool: boolean;
+    bigInt: bigint;
+    symbol: symbol;
+  };
+
+  const mapper = BreadDataMapper.create<Input, Output>({
+    str: 'a',
+    num: 'b',
+    bool: 'c',
+    bigInt: 'd',
+    symbol: 'e',
+  });
+
+  const actual = mapper.map({
+    a: 'smth',
+    b: 1,
+    c: true,
+    d: 1n,
+    e: Symbol.for('test'),
+  });
+
+  expect(actual).toEqual({
+    str: 'smth',
+    num: 1,
+    bool: true,
+    bigInt: 1n,
+    symbol: Symbol.for('test'),
+  } satisfies Output);
+});
+
+it(`should work with literal types`, async () => {
+  type Input = {
+    doesntMatter: string;
+  };
+
+  type Output = {
+    stringLiteral: 'WithLiterals';
+    numberLiteral: 100;
+    boolLiteral: false;
+    bigintLiteral: 1n;
+  };
+
+  const mapper = BreadDataMapper.create<Input, Output>({
+    stringLiteral: () => 'WithLiterals' as const,
+    boolLiteral: () => false as const,
+    numberLiteral: () => 100 as const,
+    bigintLiteral: () => 1n as const,
+  });
+
+  const actual = mapper.map({ doesntMatter: 'anything' });
+
+  expect(actual).toEqual({
+    stringLiteral: 'WithLiterals',
+    numberLiteral: 100,
+    boolLiteral: false,
+    bigintLiteral: 1n,
+  } satisfies Output);
+});
+
+it(`should work with nested objects`, async () => {
+  type Input = { a: string; b: number; c: boolean };
+
+  type Output = {
+    a: string;
+    levelOne: { b: number; levelTwo: { c: boolean } };
+  };
+
+  const mapper = BreadDataMapper.create<Input, Output>({
+    a: 'a',
+    levelOne: {
+      b: 'b',
+      levelTwo: { c: 'c' },
+    },
+  });
+
+  const actual = mapper.map({
+    a: 'a',
+    b: 1,
+    c: true,
+  });
+
+  expect(actual).toEqual({
+    a: 'a',
+    levelOne: {
+      b: 1,
+      levelTwo: { c: true },
+    },
+  } satisfies Output);
+});
+
+it(`should work with with nested native objects`, async () => {
+  type Input = { a: Date; b: Readable };
+  type Output = { nested: { date: Date; stream: Readable } };
+
+  const mapper = BreadDataMapper.create<Input, Output>({
+    nested: {
+      date: 'a',
+      stream: 'b',
+    },
+  });
+
+  const stream = new Readable();
+  const date = new Date();
+
+  const actual = mapper.map({ a: date, b: stream });
+
+  expect(actual).toEqual({ nested: { date, stream } } satisfies Output);
+});
+
+it(`should work with arrays via the factory functions`, async () => {
+  type Input = { a: string; b: number };
+  type OutputArrayItem = { type: 'A'; a: string } | { type: 'B'; b: number };
+  type Output = { array: OutputArrayItem[] };
+
+  const mapper = BreadDataMapper.create<Input, Output>({
+    array: (input) => [
+      { type: 'A', a: input.a },
+      { type: 'B', b: input.b },
+    ],
+  });
+
+  const actual = mapper.map({ a: 'val', b: 15 });
+
+  expect(actual).toEqual({
+    array: [
+      { type: 'A', a: 'val' },
+      { type: 'B', b: 15 },
+    ],
+  } satisfies Output);
+});
+
+it(`should be composable`, async () => {
+  type Input = { a: string; b: number };
+  type Foo = { fooVal: string };
+  type Bar = { barVal: number };
+  type Output = { foo: Foo; bar: Bar };
+
+  const fooMapper = BreadDataMapper.create<Input, Foo>({
+    fooVal: 'a',
+  });
+  const barMapper = BreadDataMapper.create<Input, Bar>({
+    barVal: 'b',
+  });
+
+  const outputMapper = BreadDataMapper.create<Input, Output>({
+    foo: fooMapper,
+    bar: barMapper,
+  });
+
+  const actual = outputMapper.map({ a: 'val', b: 15 });
+
+  expect(actual).toEqual({
+    foo: { fooVal: 'val' },
+    bar: { barVal: 15 },
+  } satisfies Output);
+});
+
+it(`should work with a more complex composition`, async () => {
+  type InputFoo = { a: string };
+  type Input = { foo: InputFoo };
+
+  type OutputFoo = { fooVal: string };
+  type Output = { foo: OutputFoo };
+
+  const fooMapper = BreadDataMapper.create<InputFoo, OutputFoo>({
+    fooVal: 'a',
+  });
+
+  const mapper = BreadDataMapper.create<Input, Output>({
+    foo: (i) => fooMapper.map(i.foo),
+  });
+
+  const actual = mapper.map({ foo: { a: 'val' } });
+
+  expect(actual).toEqual({ foo: { fooVal: 'val' } } satisfies Output);
+});
+
+it(`should work with missing properties`, async () => {
+  type Input = { a: string; b: number; d?: string };
+  type Output = { a: string; b: number; c: string; d: string };
+
+  const mapper = BreadDataMapper.create<Input, Output>({
+    a: 'a',
+    b: 'b',
+    c: 'd',
+    d: null,
+  });
+
+  const actual = mapper.map({ a: 'val', b: 15 });
+
+  expect(actual).toEqual({
+    a: 'val',
+    b: 15,
+    c: undefined,
+    d: null,
+  } satisfies Partial<Output>);
+});

--- a/packages/data-mapper/src/index.ts
+++ b/packages/data-mapper/src/index.ts
@@ -1,0 +1,2 @@
+export * from './lib/bread.data-map-definition';
+export * from './lib/bread.data-mapper';

--- a/packages/data-mapper/src/lib/bread.data-map-definition.ts
+++ b/packages/data-mapper/src/lib/bread.data-map-definition.ts
@@ -1,0 +1,61 @@
+import { IsLiteral, KeysByValueType } from '@easybread/common';
+
+/**
+ * Value factory for producing a value of a certain type
+ *
+ * @template I input type
+ * @template O output type
+ */
+export type BreadValueFactory<I extends object, O> = (input: I) => O;
+
+export type BreadLiteralFactory<O> = () => O;
+
+/**
+ * Constraint for the input and output types of a BreadDataMapper.
+ */
+export type BreadDataMapIOConstraint = Record<string, unknown>;
+
+export type BreadDataMapperClass<
+  TInput extends BreadDataMapIOConstraint,
+  TOutput extends BreadDataMapIOConstraint
+> = {
+  map(input: TInput): TOutput;
+};
+
+/**
+ * Resolver for a property of the map definition.
+ *
+ * @template I input type
+ * @template O output type
+ */
+export type BreadDataMapValueResolverDefinition<
+  I extends BreadDataMapIOConstraint,
+  O
+> =
+  | (O extends Array<unknown> ? BreadValueFactory<I, O> : never)
+  // if the output[key] is an object, then map recursively.
+  | (O extends Record<string, unknown>
+      ? BreadDataMapDefinition<I, O> | BreadDataMapperClass<I, O>
+      : never)
+  // if the output[key] is a literal type, then a Factory Producing the literal
+  | (IsLiteral<O> extends true ? BreadLiteralFactory<O> : never)
+  // keys of input whose values have same type as the output[key]
+  | KeysByValueType<I, O>
+  // a function to create the output value from the input
+  | BreadValueFactory<I, O>
+  // null is a special case. It means that the property is not mapped.
+  | null;
+
+/**
+ * Map definition for mapping data from one type to another.
+ *
+ * @template I input type
+ * @template O output type
+ */
+export type BreadDataMapDefinition<
+  I extends BreadDataMapIOConstraint,
+  O extends BreadDataMapIOConstraint
+> = {
+  // [K in keyof O]: BreadDataMapValueResolverDefinition<I, O[K]>;
+  [K in keyof O]: BreadDataMapValueResolverDefinition<I, O[K]>;
+};

--- a/packages/data-mapper/src/lib/bread.data-mapper.ts
+++ b/packages/data-mapper/src/lib/bread.data-mapper.ts
@@ -1,0 +1,151 @@
+import {
+  BreadDataMapDefinition,
+  BreadDataMapIOConstraint,
+  BreadDataMapperClass,
+  BreadDataMapValueResolverDefinition,
+  BreadValueFactory,
+} from './bread.data-map-definition';
+
+/**
+ * Data mapper.
+ * Maps data from one type to another.
+ *
+ * @template TInput input type
+ * @template TOutput output type
+ */
+export class BreadDataMapper<
+  TInput extends BreadDataMapIOConstraint,
+  TOutput extends BreadDataMapIOConstraint
+> implements BreadDataMapperClass<TInput, TOutput>
+{
+  /**
+   * Helper factory method.
+   * Creates a new instance of the BreadDataMapper class.
+   *
+   * @template TInput input type
+   * @template TOutput output type
+   */
+  static create<
+    TInput extends BreadDataMapIOConstraint,
+    TOutput extends BreadDataMapIOConstraint
+  >(mapDefinition: BreadDataMapDefinition<TInput, TOutput>) {
+    return new BreadDataMapper<TInput, TOutput>(mapDefinition);
+  }
+
+  constructor(private mapDefinition: BreadDataMapDefinition<TInput, TOutput>) {}
+
+  /**
+   * Maps the input to the output type.
+   */
+  map(input: TInput) {
+    return this.mapWith<TInput, TOutput>(input, this.mapDefinition);
+  }
+
+  /**
+   * Maps the input to the output type using the given map definition.
+   *
+   * @param input
+   * @param mapDefinition
+   *
+   * @template I input type
+   * @template O output type
+   */
+  private mapWith<
+    I extends BreadDataMapIOConstraint,
+    O extends BreadDataMapIOConstraint
+  >(input: I, mapDefinition: BreadDataMapDefinition<I, O>) {
+    const output = {} as O;
+
+    for (const key in mapDefinition) {
+      if (!Object.hasOwn(mapDefinition, key)) continue;
+
+      const resolver = mapDefinition[key];
+      const value = this.resolveValue<
+        I,
+        BreadDataMapDefinition<I, O>[typeof key],
+        O[typeof key]
+      >(input, resolver);
+
+      output[key] = value;
+    }
+
+    return output;
+  }
+
+  /**
+   * Resolves the value of the property using the provided resolver definition.
+   *
+   * @template I input type
+   * @template R resolver definition
+   * @template O output type
+   *
+   * @param input
+   * @param resolverDef
+   *
+   * @returns value resolved from the input
+   */
+  private resolveValue<
+    I extends BreadDataMapIOConstraint,
+    R extends BreadDataMapValueResolverDefinition<I, O>,
+    O
+  >(input: I, resolverDef: R) {
+    if (resolverDef === null) return null;
+
+    if (typeof resolverDef === 'string') {
+      return input[resolverDef] as Extract<O, string>;
+    }
+
+    if (this.isLiteralResolver<O>(resolverDef)) {
+      return resolverDef();
+    }
+
+    if (this.isFactoryResolver<I, O>(resolverDef)) return resolverDef(input);
+
+    if (
+      this.isMapperResolver<I, Extract<O, BreadDataMapIOConstraint>>(
+        resolverDef
+      )
+    ) {
+      return resolverDef.map(input);
+    }
+
+    if (
+      this.isDataMapDefinitionResolver<I, Extract<O, BreadDataMapIOConstraint>>(
+        resolverDef
+      )
+    ) {
+      return this.mapWith<I, Extract<O, BreadDataMapIOConstraint>>(
+        input,
+        resolverDef
+      );
+    }
+  }
+
+  private isDataMapDefinitionResolver<
+    I extends BreadDataMapIOConstraint,
+    O extends BreadDataMapIOConstraint
+  >(value: unknown): value is BreadDataMapDefinition<I, O> {
+    return typeof value === 'object';
+  }
+
+  private isMapperResolver<
+    I extends BreadDataMapIOConstraint,
+    O extends BreadDataMapIOConstraint
+  >(value: unknown): value is BreadDataMapperClass<I, O> {
+    return (
+      typeof value === 'object' &&
+      'map' in value &&
+      typeof value.map === 'function'
+    );
+  }
+
+  private isLiteralResolver<O>(value: unknown): value is () => O {
+    return typeof value === 'function' && value.length === 0;
+  }
+
+  private isFactoryResolver<I extends BreadDataMapIOConstraint, O>(
+    value: unknown
+  ): value is BreadValueFactory<I, O> {
+    return typeof value === 'function';
+  }
+}

--- a/packages/data-mapper/tsconfig.json
+++ b/packages/data-mapper/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs"
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/data-mapper/tsconfig.lib.json
+++ b/packages/data-mapper/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/packages/data-mapper/tsconfig.spec.json
+++ b/packages/data-mapper/tsconfig.spec.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/packages/schemas/src/lib/address.schema.ts
+++ b/packages/schemas/src/lib/address.schema.ts
@@ -1,6 +1,6 @@
 import { BreadSchema } from './bread.schema';
 
-export interface AddressSchema extends BreadSchema {
+export type AddressSchema = BreadSchema & {
   '@type': 'PostalAddress';
   streetAddress?: string;
   postalCode?: string;
@@ -8,4 +8,4 @@ export interface AddressSchema extends BreadSchema {
   addressCountry?: string;
   addressRegion?: string;
   addressLocality?: string;
-}
+};

--- a/packages/schemas/src/lib/bread.schema.ts
+++ b/packages/schemas/src/lib/bread.schema.ts
@@ -1,6 +1,4 @@
-export interface BreadSchema {
-  [key: string]: string | boolean | number | undefined | BreadSchema;
-  '@type': string;
+export type BreadSchema = {
   identifier?: string;
   name?: string;
-}
+};

--- a/packages/schemas/src/lib/organization.schema.ts
+++ b/packages/schemas/src/lib/organization.schema.ts
@@ -1,7 +1,7 @@
 import { BreadSchema } from './bread.schema';
 
-export interface OrganizationSchema extends BreadSchema {
+export type OrganizationSchema = BreadSchema & {
   '@type': 'Organization';
   alternateName?: string;
   numberOfEmployees?: number;
-}
+};

--- a/packages/schemas/src/lib/person.schema.ts
+++ b/packages/schemas/src/lib/person.schema.ts
@@ -3,24 +3,25 @@ import { Bcp47LanguageCode } from './bcp47-language-code';
 import { BreadSchema } from './bread.schema';
 import { OrganizationSchema } from './organization.schema';
 
-export interface PersonSchema extends BreadSchema {
+export type PersonSchema = BreadSchema & {
   '@type': 'Person';
   // TODO: think about allowing any string
   knowsLanguage?: Bcp47LanguageCode;
   address?: AddressSchema | string;
   alternateName?: string;
+  givenName?: string;
+  familyName?: string;
+  additionalName?: string;
+  honorificPrefix?: string;
+  honorificSuffix?: string;
   password?: string;
   identifier?: string;
   gender?: string;
-  givenName?: string;
-  familyName?: string;
   jobTitle?: string;
   telephone?: string;
   email?: string;
   image?: string;
   workLocation?: string;
-  additionalName?: string;
-  honorificPrefix?: string;
-  honorificSuffix?: string;
   worksFor?: OrganizationSchema;
-}
+  birthDate?: string;
+};

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,9 +8,9 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "importHelpers": true,
-    "target": "es2015",
+    "target": "es2023",
     "module": "esnext",
-    "lib": ["es2020", "dom"],
+    "lib": ["es2023", "dom"],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
@@ -29,8 +29,10 @@
       ],
       "@easybread/common": ["packages/common/src/index.ts"],
       "@easybread/core": ["packages/core/src/index.ts"],
+      "@easybread/data-mapper": ["packages/data-mapper/src/index.ts"],
       "@easybread/google-common": ["packages/google-common/src/index.ts"],
       "@easybread/operations": ["packages/operations/src/index.ts"],
+      "@easybread/recommended": ["tools/recommended/src/index.ts"],
       "@easybread/rocket-chat-common": [
         "packages/rocket-chat-common/src/index.ts"
       ],
@@ -39,7 +41,6 @@
         "packages/state-adapter-mongo/src/index.ts"
       ],
       "@easybread/test-utils": ["packages/test-utils/src/index.ts"],
-      "@easybread/recommended": ["tools/recommended/src/index.ts"],
       "service-adapters/bamboo-hr": [
         "packages/service-adapters/bamboo-hr/src/index.ts"
       ]


### PR DESCRIPTION
Stand-alone package for creating data mappers. 

- supports simple composability
- better type-safety than the old implementation
- more straightforward and concise interface than the old implementation

Example:
```ts
  type Input = { a: string; b: number; c: boolean };

  type Output = {
    a: string;
    levelOne: { b: number; levelTwo: { c: boolean } };
  };

  const mapper = BreadDataMapper.create<Input, Output>({
    a: 'a',
    levelOne: {
      b: 'b',
      levelTwo: { c: 'c' },
    },
  });

  const actual = mapper.map({
    a: 'a',
    b: 1,
    c: true,
  });
  ```