### PR TITLE
feat: @easybread/data-adapter package

### DIFF
--- a/packages/data-adapter/.eslintrc.json
+++ b/packages/data-adapter/.eslintrc.json
@@ -1,0 +1,30 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.json"],
+      "parser": "jsonc-eslint-parser",
+      "rules": {
+        "@nx/dependency-checks": [
+          "error",
+          {
+            "ignoredFiles": ["{projectRoot}/rollup.config.{js,ts,mjs,mts}"]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/data-adapter/.swcrc
+++ b/packages/data-adapter/.swcrc
@@ -1,0 +1,29 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    },
+    "keepClassNames": true,
+    "externalHelpers": true,
+    "loose": true
+  },
+  "module": {
+    "type": "es6"
+  },
+  "sourceMaps": true,
+  "exclude": [
+    "jest.config.ts",
+    ".*\\.spec.tsx?$",
+    ".*\\.test.tsx?$",
+    "./src/jest-setup.ts$",
+    "./**/jest-setup.ts$",
+    ".*.js$"
+  ]
+}

--- a/packages/data-adapter/README.md
+++ b/packages/data-adapter/README.md
@@ -1,0 +1,49 @@
+# data-adapter
+
+Simple module to map from and to internal and external types.
+
+### Simple Use Case
+
+```ts
+import { breadDataAdapter } from '@easybread/data-adapter';
+
+type External = { a: string; b: number };
+type Internal = { c: string; d: number };
+
+const dataAdapter = breadDataAdapter<External, Internal>({
+  toExternal: { c: 'a', d: 'b' },
+  toInternal: { a: 'c', b: 'd' },
+});
+```
+
+### Composition Use Case
+
+```ts
+import { breadDataAdapter } from '@easybread/data-adapter';
+
+type ExternalFoo = { a: string };
+type InternalFoo = { b: string };
+
+type External = { foo: ExternalFoo };
+type Internal = { foo: InternalFoo };
+
+const fooAdapter = breadDataAdapter<ExternalFoo, InternalFoo>({
+  toExternal: { b: 'a' },
+  toInternal: { a: 'b' },
+});
+
+const adapter = breadDataAdapter<External, Internal>({
+  toExternal: { foo: (i) => fooAdapter.toExternal(i.foo) },
+  toInternal: { foo: (i) => fooAdapter.toInternal(i.foo) },
+});
+```
+
+
+## Building
+
+Run `nx build data-adapter` to build the library.
+
+## Running unit tests
+
+Run `nx test data-adapter` to execute the unit tests via [Jest](https://jestjs.io).
+

--- a/packages/data-adapter/jest.config.ts
+++ b/packages/data-adapter/jest.config.ts
@@ -1,0 +1,30 @@
+/* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/nx-api/jest/documents/overview#global-setupteardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
+export default {
+  displayName: 'data-adapter',
+  preset: '../../jest.preset.js',
+  transform: {
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: '',
+  coverageDirectory: '../../coverage/packages/data-adapter',
+};

--- a/packages/data-adapter/package.json
+++ b/packages/data-adapter/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@easybread/data-adapter",
+  "version": "0.0.1",
+  "dependencies": {
+    "@easybread/data-mapper": "0.0.1"
+  },
+  "main": "./index.cjs",
+  "module": "./index.js"
+}

--- a/packages/data-adapter/project.json
+++ b/packages/data-adapter/project.json
@@ -1,0 +1,22 @@
+{
+  "name": "data-adapter",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/data-adapter/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "generatorOptions": {
+        "packageRoot": "dist/{projectRoot}",
+        "currentVersionResolver": "git-tag"
+      }
+    }
+  },
+  "tags": [],
+  "targets": {
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    }
+  }
+}

--- a/packages/data-adapter/rollup.config.js
+++ b/packages/data-adapter/rollup.config.js
@@ -1,0 +1,17 @@
+const { withNx } = require('@nx/rollup/with-nx');
+
+module.exports = withNx(
+  {
+    main: './src/index.ts',
+    outputPath: '../../dist/packages/data-adapter',
+    tsConfig: './tsconfig.lib.json',
+    compiler: 'swc',
+    format: ['cjs', 'esm'],
+    assets: [{ input: '.', output: '.', glob: '*.md' }],
+  },
+  {
+    // Provide additional rollup configuration here. See: https://rollupjs.org/configuration-options
+    // e.g.
+    // output: { sourcemap: true },
+  }
+);

--- a/packages/data-adapter/src/__tests__/data-adapter.spec.ts
+++ b/packages/data-adapter/src/__tests__/data-adapter.spec.ts
@@ -1,0 +1,49 @@
+import { breadDataAdapter } from '../lib/bread.data-adapter';
+
+type External = { a: string; b: number };
+type Internal = { c: string; d: number };
+
+const dataAdapter = breadDataAdapter<External, Internal>({
+  toExternal: { c: 'a', d: 'b' },
+  toInternal: { a: 'c', b: 'd' },
+});
+
+it('should transform external to internal', () => {
+  expect(dataAdapter.toInternal({ c: 'val', d: 15 })).toEqual({
+    a: 'val',
+    b: 15,
+  });
+});
+
+it('should transform internal to external', () => {
+  expect(dataAdapter.toExternal({ a: 'val', b: 15 })).toEqual({
+    c: 'val',
+    d: 15,
+  });
+});
+
+it(`should allow for composition`, () => {
+  type ExternalFoo = { a: string };
+  type InternalFoo = { b: string };
+
+  type External = { foo: ExternalFoo };
+  type Internal = { foo: InternalFoo };
+
+  const fooAdapter = breadDataAdapter<ExternalFoo, InternalFoo>({
+    toExternal: { b: 'a' },
+    toInternal: { a: 'b' },
+  });
+
+  // TODO: consider improving the composition pattern
+  const adapter = breadDataAdapter<External, Internal>({
+    toExternal: { foo: (i) => fooAdapter.toExternal(i.foo) },
+    toInternal: { foo: (i) => fooAdapter.toInternal(i.foo) },
+  });
+
+  expect(adapter.toExternal({ foo: { a: 'val' } })).toEqual({
+    foo: { b: 'val' },
+  });
+  expect(adapter.toInternal({ foo: { b: 'val' } })).toEqual({
+    foo: { a: 'val' },
+  });
+});

--- a/packages/data-adapter/src/index.ts
+++ b/packages/data-adapter/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/bread.data-adapter';

--- a/packages/data-adapter/src/lib/bread.data-adapter.ts
+++ b/packages/data-adapter/src/lib/bread.data-adapter.ts
@@ -1,0 +1,54 @@
+import {
+  BreadDataMapDefinition,
+  BreadDataMapIOConstraint,
+  BreadDataMapper,
+} from '@easybread/data-mapper';
+
+/**
+ * @template I Internal type
+ * @template E External type
+ */
+interface BreadDataAdapterProps<
+  I extends BreadDataMapIOConstraint,
+  E extends BreadDataMapIOConstraint
+> {
+  /** Map definition to map from internal to external type. */
+  toExternal: BreadDataMapDefinition<I, E>;
+  /** Map definition to map from external to internal type. */
+  toInternal: BreadDataMapDefinition<E, I>;
+}
+
+/**
+ * Data adapter object that maps from and to internal and external types.
+ *
+ * @template I Internal type
+ * @template E External type
+ */
+export type BreadDataAdapter<
+  I extends BreadDataMapIOConstraint,
+  E extends BreadDataMapIOConstraint
+> = {
+  toExternal(input: I): E;
+  toInternal(input: E): I;
+};
+
+/**
+ * Creates a new data adapter that maps from and to internal and external types.
+ *
+ * @template I Internal type
+ * @template E External type
+ */
+export function breadDataAdapter<
+  I extends BreadDataMapIOConstraint,
+  E extends BreadDataMapIOConstraint
+>(props: BreadDataAdapterProps<I, E>): BreadDataAdapter<I, E> {
+  const { toExternal, toInternal } = props;
+
+  const toExternalMapper = new BreadDataMapper<I, E>(toExternal);
+  const toInternalMapper = new BreadDataMapper<E, I>(toInternal);
+
+  return {
+    toExternal: (input: I) => toExternalMapper.map(input),
+    toInternal: (input: E) => toInternalMapper.map(input),
+  };
+}

--- a/packages/data-adapter/tsconfig.json
+++ b/packages/data-adapter/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs"
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/data-adapter/tsconfig.lib.json
+++ b/packages/data-adapter/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/packages/data-adapter/tsconfig.spec.json
+++ b/packages/data-adapter/tsconfig.spec.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/packages/data-mapper/src/lib/bread.data-mapper.ts
+++ b/packages/data-mapper/src/lib/bread.data-mapper.ts
@@ -88,7 +88,7 @@ export class BreadDataMapper<
     I extends BreadDataMapIOConstraint,
     R extends BreadDataMapValueResolverDefinition<I, O>,
     O
-  >(input: I, resolverDef: R) {
+  >(input: I, resolverDef: R): O {
     if (resolverDef === null) return null;
 
     if (typeof resolverDef === 'string') {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -29,6 +29,7 @@
       ],
       "@easybread/common": ["packages/common/src/index.ts"],
       "@easybread/core": ["packages/core/src/index.ts"],
+      "@easybread/data-adapter": ["packages/data-adapter/src/index.ts"],
       "@easybread/data-mapper": ["packages/data-mapper/src/index.ts"],
       "@easybread/google-common": ["packages/google-common/src/index.ts"],
       "@easybread/operations": ["packages/operations/src/index.ts"],


### PR DESCRIPTION
Simple module to map from and to internal and external types.

### Simple Use Case

```ts
import { breadDataAdapter } from '@easybread/data-adapter';

type External = { a: string; b: number };
type Internal = { c: string; d: number };

const dataAdapter = breadDataAdapter<External, Internal>({
  toExternal: { c: 'a', d: 'b' },
  toInternal: { a: 'c', b: 'd' },
});
```

### Composition Use Case

```ts
import { breadDataAdapter } from '@easybread/data-adapter';

type ExternalFoo = { a: string };
type InternalFoo = { b: string };

type External = { foo: ExternalFoo };
type Internal = { foo: InternalFoo };

const fooAdapter = breadDataAdapter<ExternalFoo, InternalFoo>({
  toExternal: { b: 'a' },
  toInternal: { a: 'b' },
});

const adapter = breadDataAdapter<External, Internal>({
  toExternal: { foo: (i) => fooAdapter.toExternal(i.foo) },
  toInternal: { foo: (i) => fooAdapter.toInternal(i.foo) },
});
```