### PR TITLE
chore: Discord notifications for PR and Publish

### DIFF
--- a/.github/workflows/ci-pr-dev.yml
+++ b/.github/workflows/ci-pr-dev.yml
@@ -55,3 +55,13 @@ jobs:
       - run: pnpm exec nx affected -t lint test build --verbose
         env:
           NX_BASE: origin/develop
+
+      - name: Notify Discord
+        uses: sarisia/actions-status-discord@v1.14.6
+        if: always()
+        with:
+          webhook: ${{ secrets.DISCORD_ACTIONS_WEBHOOK }}
+          status: ${{ job.status }}
+          title: "CI PR Dev - ${{ github.workflow }}"
+          description: "Branch: ${{ github.ref }} - Commit: ${{ github.sha }}"
+          color: ${{ job.status == 'success' && '0x25E565' || '0xEF4650' }}

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -43,9 +43,43 @@ jobs:
         run: pnpm dlx nx report
         shell: bash
 
+      - name: Print Version
+        run: { echo Version: "${{ github.ref_name }}" }
+
+      # For some reason, `nx release publish` doesn't build the packages (`nx release` does)
+      # even if we set `"dependsOn": [ "build" ]` in the nx.json file for the `nx-release-publish` target.
+      # So we build manually
+      - name: Build packages
+
+        run: pnpm dlx nx run-many -t build
+        shell: bash
+
       - name: Publish packages
+        id: publish
         run: pnpm dlx nx release publish
         shell: bash
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+
+      - name: Notify Success to Discord
+        uses: sarisia/actions-status-discord@v1.14.6
+        if: ${{ steps.publish.outcome == 'success' }}
+        with:
+          webhook: ${{ secrets.DISCORD_ACTIONS_WEBHOOK }}
+          status: ${{ job.status }}
+          title: "Release - ${{ github.workflow }}"
+          description: "Tag: ${{ github.ref }} - Commit: ${{ github.sha }}"
+          content: "Release Job successful!"
+          color: 0x25e565
+
+      - name: Notify Failure to Discord
+        uses: sarisia/actions-status-discord@v1.14.6
+        if: ${{ job.status == 'failure' }}
+        with:
+          webhook: ${{ secrets.DISCORD_ACTIONS_WEBHOOK }}
+          status: ${{ job.status }}
+          title: "Release - ${{ github.workflow }}"
+          description: "Tag: ${{ github.ref }} - Commit: ${{ github.sha }}"
+          content: "Release Job Failed!"
+          color: 0xEF4650

--- a/nx.json
+++ b/nx.json
@@ -2,11 +2,15 @@
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "defaultBase": "develop",
   "release": {
+    "projects": ["packages/**"],
     "version": {
       "preVersionCommand": "pnpm dlx nx run-many -t build"
     }
   },
   "targetDefaults": {
+    "nx-release-publish": {
+      "dependsOn": ["build", "^build"]
+    },
     "test": {
       "options": {
         "args": ["--passWithNoTests"]


### PR DESCRIPTION
**Done:**
- notify on any outcome of the ci-pr workflow
- notify success/failure of the ci-release workflow

**Todo:**
- add github release action after publishing to npm
- add a gh actions workflow that triggers on a new release to tweet/discord/LinkedIn about it
- notify Discord when a PR is created/updated/merged

---
closes #116 