### PR TITLE
feat: @easybread/pagination-adapter

### DIFF
--- a/packages/core/src/lib/operation/bread-operation-pagination.ts
+++ b/packages/core/src/lib/operation/bread-operation-pagination.ts
@@ -3,39 +3,38 @@ export type BreadOperationPaginationType =
   | 'PREV_NEXT'
   | 'DISABLED';
 
-export interface BreadOperationPaginationBase<
+export type BreadOperationPaginationBase<
   TType extends BreadOperationPaginationType
-> {
+> = {
   type: TType;
-}
+};
 
-export type BreadOperationDisabledPagination = BreadOperationPaginationBase<
-  'DISABLED'
->;
+export type BreadOperationDisabledPagination =
+  BreadOperationPaginationBase<'DISABLED'>;
 
-export interface BreadOperationSkipCountInputPagination
-  extends BreadOperationPaginationBase<'SKIP_COUNT'> {
-  skip: number;
-  count: number;
-}
+export type BreadOperationSkipCountInputPagination =
+  BreadOperationPaginationBase<'SKIP_COUNT'> & {
+    skip: number;
+    count: number;
+  };
 
-export interface BreadOperationSkipCountOutputPagination
-  extends BreadOperationPaginationBase<'SKIP_COUNT'> {
-  skip: number;
-  count: number;
-  totalCount: number;
-}
+export type BreadOperationSkipCountOutputPagination =
+  BreadOperationPaginationBase<'SKIP_COUNT'> & {
+    skip: number;
+    count: number;
+    totalCount: number;
+  };
 
-export interface BreadOperationPrevNextInputPagination
-  extends BreadOperationPaginationBase<'PREV_NEXT'> {
-  page?: string | number;
-}
+export type BreadOperationPrevNextInputPagination =
+  BreadOperationPaginationBase<'PREV_NEXT'> & {
+    page?: string | number;
+  };
 
-export interface BreadOperationPrevNextOutputPagination
-  extends BreadOperationPaginationBase<'PREV_NEXT'> {
-  prev?: string | number;
-  next?: string | number;
-}
+export type BreadOperationPrevNextOutputPagination =
+  BreadOperationPaginationBase<'PREV_NEXT'> & {
+    prev?: string | number;
+    next?: string | number;
+  };
 
 type BreadOperationInputPaginationUnion =
   | BreadOperationSkipCountInputPagination

--- a/packages/pagination-adapter/.eslintrc.json
+++ b/packages/pagination-adapter/.eslintrc.json
@@ -1,0 +1,30 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.json"],
+      "parser": "jsonc-eslint-parser",
+      "rules": {
+        "@nx/dependency-checks": [
+          "error",
+          {
+            "ignoredFiles": ["{projectRoot}/rollup.config.{js,ts,mjs,mts}"]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/pagination-adapter/.swcrc
+++ b/packages/pagination-adapter/.swcrc
@@ -1,0 +1,29 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    },
+    "keepClassNames": true,
+    "externalHelpers": true,
+    "loose": true
+  },
+  "module": {
+    "type": "es6"
+  },
+  "sourceMaps": true,
+  "exclude": [
+    "jest.config.ts",
+    ".*\\.spec.tsx?$",
+    ".*\\.test.tsx?$",
+    "./src/jest-setup.ts$",
+    "./**/jest-setup.ts$",
+    ".*.js$"
+  ]
+}

--- a/packages/pagination-adapter/README.md
+++ b/packages/pagination-adapter/README.md
@@ -1,0 +1,62 @@
+# pagination-adapter
+
+Maps internal pagination params to external and external pagination response to internal.
+
+**Example:**
+
+```ts
+import { breadPaginationAdapter } from '@easybread/pagination-adapter';
+
+type InternalParams = {
+  skip: number;
+  count: number;
+};
+
+type InternalData = {
+  skip: number;
+  count: number;
+  totalCount: number;
+};
+
+type ExternalParams = {
+  page: number;
+  pageSize: number;
+};
+
+type ExternalData = {
+  page: number;
+  pageSize: number;
+  totalCount: number;
+};
+
+const paginationAdapter = breadPaginationAdapter<
+  InternalParams,
+  InternalData,
+  ExternalParams,
+  ExternalData
+>({
+  toExternalParams: {
+    page: (_) => ~~(_.skip / _.count) + 1,
+    pageSize: 'count',
+  },
+  toInternalData: {
+    skip: (_) => (_.page - 1) * _.pageSize,
+    count: 'pageSize',
+    totalCount: 'totalCount',
+  },
+});
+
+paginationAdapter.toExternalParams({ skip: 0, count: 20 })
+
+paginationAdapter.toInternalData({ page: 1, pageSize: 20, totalCount: 99 })
+
+```
+
+**Note:**
+
+There are possible limitations, that are out of our control.
+
+For example, if the internal data supposed to have `totalCount` 
+and external API with page-based pagination returns`totalPagesCount` 
+(not total count of all found items, which is a bad API design in general),
+there is no way to calculate the `totalCount` correctly.

--- a/packages/pagination-adapter/jest.config.ts
+++ b/packages/pagination-adapter/jest.config.ts
@@ -1,0 +1,30 @@
+/* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/nx-api/jest/documents/overview#global-setupteardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
+export default {
+  displayName: 'pagination-adapter',
+  preset: '../../jest.preset.js',
+  transform: {
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: '',
+  coverageDirectory: '../../coverage/packages/pagination-adapter',
+};

--- a/packages/pagination-adapter/package.json
+++ b/packages/pagination-adapter/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@easybread/pagination-adapter",
+  "version": "0.0.1",
+  "dependencies": {
+    "@easybread/data-mapper": "0.0.1"
+  },
+  "main": "./index.cjs",
+  "module": "./index.js"
+}

--- a/packages/pagination-adapter/project.json
+++ b/packages/pagination-adapter/project.json
@@ -1,0 +1,22 @@
+{
+  "name": "pagination-adapter",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pagination-adapter/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "generatorOptions": {
+        "packageRoot": "dist/{projectRoot}",
+        "currentVersionResolver": "git-tag"
+      }
+    }
+  },
+  "tags": [],
+  "targets": {
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    }
+  }
+}

--- a/packages/pagination-adapter/rollup.config.js
+++ b/packages/pagination-adapter/rollup.config.js
@@ -1,0 +1,17 @@
+const { withNx } = require('@nx/rollup/with-nx');
+
+module.exports = withNx(
+  {
+    main: './src/index.ts',
+    outputPath: '../../dist/packages/pagination-adapter',
+    tsConfig: './tsconfig.lib.json',
+    compiler: 'swc',
+    format: ['cjs', 'esm'],
+    assets: [{ input: '.', output: '.', glob: '*.md' }],
+  },
+  {
+    // Provide additional rollup configuration here. See: https://rollupjs.org/configuration-options
+    // e.g.
+    // output: { sourcemap: true },
+  }
+);

--- a/packages/pagination-adapter/src/__tests__/bread.pagination-adapter.spec.ts
+++ b/packages/pagination-adapter/src/__tests__/bread.pagination-adapter.spec.ts
@@ -1,0 +1,93 @@
+import { breadPaginationAdapter } from '../lib/bread.pagination-adapter';
+type InternalParams = {
+  skip: number;
+  count: number;
+};
+
+type InternalData = {
+  skip: number;
+  count: number;
+  totalCount: number;
+};
+
+type ExternalParams = {
+  page: number;
+  pageSize: number;
+};
+
+type ExternalData = {
+  page: number;
+  pageSize: number;
+  totalCount: number;
+};
+
+const adapter = breadPaginationAdapter<
+  InternalParams,
+  InternalData,
+  ExternalParams,
+  ExternalData
+>({
+  toExternalParams: {
+    page: (_) => ~~(_.skip / _.count) + 1,
+    pageSize: 'count',
+  },
+  toInternalData: {
+    skip: (_) => (_.page - 1) * _.pageSize,
+    count: 'pageSize',
+    totalCount: 'totalCount',
+  },
+});
+
+it(`should map to external params correctly`, () => {
+  expect(adapter.toExternalParams({ skip: 0, count: 20 })).toEqual({
+    page: 1,
+    pageSize: 20,
+  });
+
+  expect(
+    adapter.toExternalParams({
+      skip: 19,
+      count: 20,
+    })
+  ).toEqual({ page: 1, pageSize: 20 } satisfies ExternalParams);
+
+  expect(
+    adapter.toExternalParams({
+      skip: 20,
+      count: 20,
+    })
+  ).toEqual({ page: 2, pageSize: 20 } satisfies ExternalParams);
+
+  expect(
+    adapter.toExternalParams({
+      skip: 21,
+      count: 20,
+    })
+  ).toEqual({ page: 2, pageSize: 20 } satisfies ExternalParams);
+});
+
+it(`should map to internal data correctly`, () => {
+  expect(
+    adapter.toInternalData({ page: 1, pageSize: 20, totalCount: 99 })
+  ).toEqual({
+    skip: 0,
+    count: 20,
+    totalCount: 99,
+  });
+
+  expect(
+    adapter.toInternalData({ page: 2, pageSize: 20, totalCount: 99 })
+  ).toEqual({
+    skip: 20,
+    count: 20,
+    totalCount: 99,
+  });
+
+  expect(
+    adapter.toInternalData({ page: 3, pageSize: 20, totalCount: 99 })
+  ).toEqual({
+    skip: 40,
+    count: 20,
+    totalCount: 99,
+  });
+});

--- a/packages/pagination-adapter/src/index.ts
+++ b/packages/pagination-adapter/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/bread.pagination-adapter';

--- a/packages/pagination-adapter/src/lib/bread.pagination-adapter.ts
+++ b/packages/pagination-adapter/src/lib/bread.pagination-adapter.ts
@@ -1,0 +1,77 @@
+import {
+  BreadDataMapDefinition,
+  BreadDataMapIOConstraint,
+  BreadDataMapper,
+} from '@easybread/data-mapper';
+
+/**
+ * Params for creating a new pagination adapter.
+ *
+ * @template IP internal params type
+ * @template ID internal data type
+ * @template EP external params type
+ * @template ED external data type
+ */
+export interface BreadPaginationAdapterParams<
+  IP extends BreadDataMapIOConstraint,
+  ID extends BreadDataMapIOConstraint,
+  EP extends BreadDataMapIOConstraint,
+  ED extends BreadDataMapIOConstraint
+> {
+  /** Map definition to map from internal params to external params. */
+  toExternalParams: BreadDataMapDefinition<IP, EP>;
+  /** Map definition to map from external data to internal data. */
+  toInternalData: BreadDataMapDefinition<ED, ID>;
+}
+
+/**
+ * Pagination adapter object that maps
+ * internal params to external params and
+ * external data to internal data.
+ *
+ * @template IP internal params type
+ * @template ID internal data type
+ * @template EP external params type
+ * @template ED external data type
+ */
+export type BreadPaginationAdapter<
+  IP extends BreadDataMapIOConstraint,
+  ID extends BreadDataMapIOConstraint,
+  EP extends BreadDataMapIOConstraint,
+  ED extends BreadDataMapIOConstraint
+> = {
+  /** Map from internal params to external params. */
+  toExternalParams: (input: IP) => EP;
+  /** Map from external data to internal data. */
+  toInternalData: (input: ED) => ID;
+};
+
+/**
+ * Create a new pagination adapter, that transforms
+ * internal params to external params and
+ * external data to internal data.
+ * (to send out params and receive data, with transformations)
+ *
+ * @template ID internal data type
+ * @template IP internal params type
+ * @template ED external data type
+ * @template EP external params type
+ */
+export function breadPaginationAdapter<
+  IP extends BreadDataMapIOConstraint,
+  ID extends BreadDataMapIOConstraint,
+  EP extends BreadDataMapIOConstraint,
+  ED extends BreadDataMapIOConstraint
+>(
+  props: BreadPaginationAdapterParams<IP, ID, EP, ED>
+): BreadPaginationAdapter<IP, ID, EP, ED> {
+  const { toExternalParams, toInternalData } = props;
+
+  const toExternalParamsMapper = new BreadDataMapper<IP, EP>(toExternalParams);
+  const toInternalDataMapper = new BreadDataMapper<ED, ID>(toInternalData);
+
+  return {
+    toExternalParams: (input: IP) => toExternalParamsMapper.map(input),
+    toInternalData: (input: ED) => toInternalDataMapper.map(input),
+  };
+}

--- a/packages/pagination-adapter/tsconfig.json
+++ b/packages/pagination-adapter/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs"
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/pagination-adapter/tsconfig.lib.json
+++ b/packages/pagination-adapter/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/packages/pagination-adapter/tsconfig.spec.json
+++ b/packages/pagination-adapter/tsconfig.spec.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -33,6 +33,9 @@
       "@easybread/data-mapper": ["packages/data-mapper/src/index.ts"],
       "@easybread/google-common": ["packages/google-common/src/index.ts"],
       "@easybread/operations": ["packages/operations/src/index.ts"],
+      "@easybread/pagination-adapter": [
+        "packages/pagination-adapter/src/index.ts"
+      ],
       "@easybread/recommended": ["tools/recommended/src/index.ts"],
       "@easybread/rocket-chat-common": [
         "packages/rocket-chat-common/src/index.ts"


### PR DESCRIPTION
Maps internal pagination params to external and external pagination response to internal.

**Example:**

```ts
import { breadPaginationAdapter } from '@easybread/pagination-adapter';

type InternalParams = {
  skip: number;
  count: number;
};

type InternalData = {
  skip: number;
  count: number;
  totalCount: number;
};

type ExternalParams = {
  page: number;
  pageSize: number;
};

type ExternalData = {
  page: number;
  pageSize: number;
  totalCount: number;
};

const paginationAdapter = breadPaginationAdapter<
  InternalParams,
  InternalData,
  ExternalParams,
  ExternalData
>({
  toExternalParams: {
    page: (_) => ~~(_.skip / _.count) + 1,
    pageSize: 'count',
  },
  toInternalData: {
    skip: (_) => (_.page - 1) * _.pageSize,
    count: 'pageSize',
    totalCount: 'totalCount',
  },
});

paginationAdapter.toExternalParams({ skip: 0, count: 20 })

paginationAdapter.toInternalData({ page: 1, pageSize: 20, totalCount: 99 })

```

**Note:**

There are possible limitations, that are out of our control.

For example, if the internal data supposed to have `totalCount` 
and external API with page-based pagination returns`totalPagesCount` 
(not total count of all found items, which is a bad API design in general),
there is no way to calculate the `totalCount` correctly.


---

refs #115 