### PR TITLE
fix: better types, various fixes

### DIFF
--- a/.github/workflows/ci-pr-dev.yml
+++ b/.github/workflows/ci-pr-dev.yml
@@ -43,12 +43,6 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: List all remotes
-        run: git remote -v
-
-      - name: List all branches
-        run: git branch -a --no-color
-
       # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
       # - run: pnpm exec nx-cloud record -- echo Hello World
       # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -50,7 +50,6 @@ jobs:
       # even if we set `"dependsOn": [ "build" ]` in the nx.json file for the `nx-release-publish` target.
       # So we build manually
       - name: Build packages
-
         run: pnpm dlx nx run-many -t build
         shell: bash
 

--- a/packages/common/jest.config.ts
+++ b/packages/common/jest.config.ts
@@ -13,6 +13,10 @@ if (swcJestConfig.swcrc === undefined) {
   swcJestConfig.swcrc = false;
 }
 
+if (swcJestConfig !== undefined) {
+  swcJestConfig.sourceMaps = 'inline';
+}
+
 // Uncomment if using global setup/teardown files being transformed via swc
 // https://nx.dev/nx-api/jest/documents/overview#global-setupteardown-with-nx-libraries
 // jest needs EsModule Interop to find the default exported setup/teardown functions

--- a/packages/core/jest.config.ts
+++ b/packages/core/jest.config.ts
@@ -13,6 +13,10 @@ if (swcJestConfig.swcrc === undefined) {
   swcJestConfig.swcrc = false;
 }
 
+if (swcJestConfig !== undefined) {
+  swcJestConfig.sourceMaps = 'inline';
+}
+
 // Uncomment if using global setup/teardown files being transformed via swc
 // https://nx.dev/nx-api/jest/documents/overview#global-setupteardown-with-nx-libraries
 // jest needs EsModule Interop to find the default exported setup/teardown functions

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,3 +9,4 @@ export * from './lib/state-adapters';
 export * from './lib/data-mapper';
 export * from './lib/event-bus/bread-event.bus';
 export * from './lib/event-bus/bread.event';
+export * from './lib/transport/http';

--- a/packages/core/src/lib/__mocks__/axios.ts
+++ b/packages/core/src/lib/__mocks__/axios.ts
@@ -1,6 +1,0 @@
-const axios = jest.requireActual('axios');
-
-module.exports = {
-  ...axios,
-  request: jest.fn(() => Promise.resolve({ status: 500 })),
-};

--- a/packages/core/src/lib/client/easy-bread-client.spec.ts
+++ b/packages/core/src/lib/client/easy-bread-client.spec.ts
@@ -33,22 +33,22 @@ class TestAuthStrategy extends BreadAuthStrategy<object> {
 }
 
 interface TestSkipCountOperation
-  extends BreadCollectionOperation<'TEST', 'SKIP_COUNT'> {
-  input: BreadCollectionOperationInput<'TEST', 'SKIP_COUNT'>;
+  extends BreadCollectionOperation<'TEST_SKIP_COUNT', 'SKIP_COUNT'> {
+  input: BreadCollectionOperationInput<'TEST_SKIP_COUNT', 'SKIP_COUNT'>;
 
   output: BreadCollectionOperationOutputWithPayload<
-    'TEST',
+    'TEST_SKIP_COUNT',
     PersonSchema[],
     'SKIP_COUNT'
   >;
 }
 
 interface TestPrevNextOperation
-  extends BreadCollectionOperation<'TEST', 'PREV_NEXT'> {
-  input: BreadCollectionOperationInput<'TEST', 'PREV_NEXT'>;
+  extends BreadCollectionOperation<'TEST_PREV_NEXT', 'PREV_NEXT'> {
+  input: BreadCollectionOperationInput<'TEST_PREV_NEXT', 'PREV_NEXT'>;
 
   output: BreadCollectionOperationOutputWithPayload<
-    'TEST',
+    'TEST_PREV_NEXT',
     PersonSchema[],
     'PREV_NEXT'
   >;
@@ -74,24 +74,23 @@ describe('allPages() async generator function', () => {
     beforeEach(() => {
       const totalCount = 378;
       jest.restoreAllMocks();
-      jest.spyOn(client, 'invoke').mockImplementation(
-        // TODO: find out why ts complains
-        async (input: OperationTypes['input']) => {
-          if (input.pagination.type === 'PREV_NEXT') {
-            throw new Error('PREV_NEXT not supported in this test');
-          }
+      jest.spyOn(client, 'invoke').mockImplementation(async (input) => {
+        if (!('pagination' in input)) throw new Error('No pagination');
 
-          const { pagination, name } = input;
+        const { pagination, name } = input;
 
-          return {
-            name,
-            pagination: { ...pagination, totalCount },
-            provider: 'Test',
-            payload: [],
-            rawPayload: { success: true },
-          };
+        if (input.pagination.type === 'PREV_NEXT') {
+          throw new Error('PREV_NEXT not supported in this test');
         }
-      );
+
+        return {
+          name,
+          pagination: { ...pagination, totalCount },
+          provider: 'Test',
+          payload: [],
+          rawPayload: { success: true },
+        } as OperationTypes['output'];
+      });
     });
 
     it(`should return an async generator`, () => {
@@ -101,7 +100,7 @@ describe('allPages() async generator function', () => {
           count: 120,
           skip: 0,
         },
-        name: 'TEST',
+        name: 'TEST_SKIP_COUNT',
         breadId: '1',
       });
 
@@ -111,7 +110,7 @@ describe('allPages() async generator function', () => {
           count: 120,
           skip: 0,
         },
-        name: 'TEST',
+        name: 'TEST_SKIP_COUNT',
         breadId: '1',
       });
 
@@ -127,7 +126,7 @@ describe('allPages() async generator function', () => {
           count: 120,
           skip: 0,
         },
-        name: 'TEST',
+        name: 'TEST_SKIP_COUNT',
         breadId: '1',
       })) {
         results.push(result);
@@ -137,28 +136,28 @@ describe('allPages() async generator function', () => {
         [
           {
             breadId: '1',
-            name: 'TEST',
+            name: 'TEST_SKIP_COUNT',
             pagination: { count: 120, skip: 0, type: 'SKIP_COUNT' },
           },
         ],
         [
           {
             breadId: '1',
-            name: 'TEST',
+            name: 'TEST_SKIP_COUNT',
             pagination: { count: 120, skip: 120, type: 'SKIP_COUNT' },
           },
         ],
         [
           {
             breadId: '1',
-            name: 'TEST',
+            name: 'TEST_SKIP_COUNT',
             pagination: { count: 120, skip: 240, type: 'SKIP_COUNT' },
           },
         ],
         [
           {
             breadId: '1',
-            name: 'TEST',
+            name: 'TEST_SKIP_COUNT',
             pagination: { count: 120, skip: 360, type: 'SKIP_COUNT' },
           },
         ],
@@ -166,7 +165,7 @@ describe('allPages() async generator function', () => {
 
       expect(results).toEqual([
         {
-          name: 'TEST',
+          name: 'TEST_SKIP_COUNT',
           pagination: {
             count: 120,
             skip: 0,
@@ -178,7 +177,7 @@ describe('allPages() async generator function', () => {
           rawPayload: { success: true },
         },
         {
-          name: 'TEST',
+          name: 'TEST_SKIP_COUNT',
           pagination: {
             count: 120,
             skip: 120,
@@ -190,7 +189,7 @@ describe('allPages() async generator function', () => {
           rawPayload: { success: true },
         },
         {
-          name: 'TEST',
+          name: 'TEST_SKIP_COUNT',
           pagination: {
             count: 120,
             skip: 240,
@@ -202,7 +201,7 @@ describe('allPages() async generator function', () => {
           rawPayload: { success: true },
         },
         {
-          name: 'TEST',
+          name: 'TEST_SKIP_COUNT',
           pagination: {
             count: 120,
             skip: 360,
@@ -231,23 +230,23 @@ describe('allPages() async generator function', () => {
       };
 
       jest.restoreAllMocks();
-      jest
-        .spyOn(client, 'invoke')
-        .mockImplementation(async (input: OperationTypes['input']) => {
-          if (input.pagination.type === 'SKIP_COUNT') {
-            throw new Error('PREV_NEXT not supported in this test');
-          }
+      jest.spyOn(client, 'invoke').mockImplementation(async (input) => {
+        if (!('pagination' in input)) throw new Error('No pagination');
 
-          const { pagination, name } = input;
-          const next = createNextPage(pagination.page);
-          return {
-            name,
-            pagination: { type: 'PREV_NEXT', next },
-            provider: 'Test',
-            payload: [],
-            rawPayload: { success: true },
-          };
-        });
+        if (input.pagination.type === 'SKIP_COUNT') {
+          throw new Error('PREV_NEXT not supported in this test');
+        }
+
+        const { pagination, name } = input;
+        const next = createNextPage(pagination.page);
+        return {
+          name,
+          pagination: { type: 'PREV_NEXT', next },
+          provider: 'Test',
+          payload: [],
+          rawPayload: { success: true },
+        } as OperationTypes['output'];
+      });
     });
 
     it(`should fetch the entire collection`, async () => {
@@ -255,7 +254,7 @@ describe('allPages() async generator function', () => {
 
       for await (const result of client.allPages<TestPrevNextOperation>({
         pagination: { type: 'PREV_NEXT' },
-        name: 'TEST',
+        name: 'TEST_PREV_NEXT',
         breadId: '1',
       })) {
         results.push(result);
@@ -265,28 +264,28 @@ describe('allPages() async generator function', () => {
         [
           {
             breadId: '1',
-            name: 'TEST',
+            name: 'TEST_PREV_NEXT',
             pagination: { type: 'PREV_NEXT' },
           },
         ],
         [
           {
             breadId: '1',
-            name: 'TEST',
+            name: 'TEST_PREV_NEXT',
             pagination: { page: 1, type: 'PREV_NEXT' },
           },
         ],
         [
           {
             breadId: '1',
-            name: 'TEST',
+            name: 'TEST_PREV_NEXT',
             pagination: { page: 2, type: 'PREV_NEXT' },
           },
         ],
         [
           {
             breadId: '1',
-            name: 'TEST',
+            name: 'TEST_PREV_NEXT',
             pagination: { page: 3, type: 'PREV_NEXT' },
           },
         ],
@@ -294,28 +293,28 @@ describe('allPages() async generator function', () => {
 
       expect(results).toEqual([
         {
-          name: 'TEST',
+          name: 'TEST_PREV_NEXT',
           pagination: { next: 1, type: 'PREV_NEXT' },
           payload: [],
           provider: 'Test',
           rawPayload: { success: true },
         },
         {
-          name: 'TEST',
+          name: 'TEST_PREV_NEXT',
           pagination: { next: 2, type: 'PREV_NEXT' },
           payload: [],
           provider: 'Test',
           rawPayload: { success: true },
         },
         {
-          name: 'TEST',
+          name: 'TEST_PREV_NEXT',
           pagination: { next: 3, type: 'PREV_NEXT' },
           payload: [],
           provider: 'Test',
           rawPayload: { success: true },
         },
         {
-          name: 'TEST',
+          name: 'TEST_PREV_NEXT',
           pagination: { type: 'PREV_NEXT' },
           payload: [],
           provider: 'Test',
@@ -330,7 +329,7 @@ describe('allPages() async generator function', () => {
       const id = '1';
       await client.unAuthenticate(id);
       await expect(authStrategy.readAuthData(id)).rejects.toThrowError(
-        `no auth data in the state for user 1`
+        `no auth data in the state for 1`
       );
     });
   });

--- a/packages/core/src/lib/exception/bread-exception.ts
+++ b/packages/core/src/lib/exception/bread-exception.ts
@@ -6,14 +6,16 @@ export class BreadException extends Error {
   toJSON(): object {
     return {
       ...this.valueOf(),
-      message: this.message
+      name: this.constructor.name,
+      message: this.message,
     };
   }
 
   toObject(): object {
     return {
       ...this.valueOf(),
-      message: this.message
+      name: this.constructor.name,
+      message: this.message,
     };
   }
 }

--- a/packages/core/src/lib/exception/no-auth-data.exception.ts
+++ b/packages/core/src/lib/exception/no-auth-data.exception.ts
@@ -2,6 +2,6 @@ import { BreadException } from './bread-exception';
 
 export class NoAuthDataException extends BreadException {
   constructor(breadId: string) {
-    super(`no auth data in the state for user ${breadId}`);
+    super(`no auth data in the state for ${breadId}`);
   }
 }

--- a/packages/core/src/lib/exception/retries-limit-reached.exception.ts
+++ b/packages/core/src/lib/exception/retries-limit-reached.exception.ts
@@ -11,12 +11,12 @@ export interface RetriesLimitReachedExceptionProps {
 }
 
 export class RetriesLimitReachedException extends BreadException {
-  private startTime: RetriesLimitReachedExceptionProps['startTime'];
-  private endTime: RetriesLimitReachedExceptionProps['endTime'];
-  private operationName: RetriesLimitReachedExceptionProps['operationName'];
-  private input: RetriesLimitReachedExceptionProps['input'];
-  private options: RetriesLimitReachedExceptionProps['options'];
-  private retriesCount: RetriesLimitReachedExceptionProps['retriesCount'];
+  startTime: RetriesLimitReachedExceptionProps['startTime'];
+  endTime: RetriesLimitReachedExceptionProps['endTime'];
+  operationName: RetriesLimitReachedExceptionProps['operationName'];
+  input: RetriesLimitReachedExceptionProps['input'];
+  options: RetriesLimitReachedExceptionProps['options'];
+  retriesCount: RetriesLimitReachedExceptionProps['retriesCount'];
 
   constructor({
     retriesCount,

--- a/packages/core/src/lib/operation-executor/operation-executor.ts
+++ b/packages/core/src/lib/operation-executor/operation-executor.ts
@@ -1,6 +1,7 @@
 import {
   BreadOperationContext,
   type BreadOperationHandler,
+  type BreadOperationError,
   type InferOperationHandlerOperation,
 } from '../operation';
 import { BreadServiceAdapterOptions } from '../common-interfaces';
@@ -13,7 +14,7 @@ interface OperationExecutorProps<
   handler: THandler;
   input: InferOperationHandlerOperation<THandler>['input'];
   options: BreadServiceAdapterOptions | null;
-  context: BreadOperationContext<any, any, any>;
+  context: BreadOperationContext<any>;
 }
 
 // TODO:
@@ -72,8 +73,15 @@ export class OperationExecutor<
   }
 
   private shouldRetry(error: unknown): boolean {
+    if (!BreadHttpTransport.isHttpError(error)) return false;
+
     const handlerDecision = this.handler.shouldRetry
-      ? this.handler.shouldRetry(error, this.retriesCount)
+      ? this.handler.shouldRetry(
+          error as BreadOperationError<
+            InferOperationHandlerOperation<THandler>
+          >,
+          this.retriesCount
+        )
       : null;
 
     if (handlerDecision === null) return this.isKnownRetryEligibleError(error);

--- a/packages/core/src/lib/operation/bread-operation-context.ts
+++ b/packages/core/src/lib/operation/bread-operation-context.ts
@@ -1,42 +1,25 @@
 import { AxiosRequestConfig, AxiosResponse } from 'axios';
 
 import { BreadAuthStrategy } from '../auth-strategy';
-import { EasyBreadClient } from '../client';
-import { BreadServiceAdapterOptions } from '../common-interfaces';
 import { BreadStateAdapter } from '../state';
 import { BreadHttpTransport } from '../transport/http';
-import { BreadOperation } from './bread-operation';
 
 interface BreadOperationContextOptions<
-  TOperations extends BreadOperation<string>,
-  TAuthStrategy extends BreadAuthStrategy<object>,
-  TOptions extends BreadServiceAdapterOptions | null = null
+  TAuth extends BreadAuthStrategy<object>
 > {
-  readonly state: BreadStateAdapter;
-  readonly client: EasyBreadClient<TOperations, TAuthStrategy, TOptions>;
-  readonly auth: TAuthStrategy;
   readonly breadId: string;
+  readonly state: BreadStateAdapter;
+  readonly auth: TAuth;
 }
 
-export class BreadOperationContext<
-  TOperation extends BreadOperation<string>,
-  TAuthStrategy extends BreadAuthStrategy<object>,
-  TOptions extends BreadServiceAdapterOptions | null = null
-> {
+export class BreadOperationContext<TAuth extends BreadAuthStrategy<object>> {
+  readonly auth: TAuth;
   readonly state: BreadStateAdapter;
-  readonly client: EasyBreadClient<TOperation, TAuthStrategy, TOptions>;
-  readonly auth: TAuthStrategy;
   readonly http: BreadHttpTransport;
   readonly breadId: string;
 
-  constructor({
-    state,
-    client,
-    auth,
-    breadId,
-  }: BreadOperationContextOptions<TOperation, TAuthStrategy, TOptions>) {
+  constructor({ state, auth, breadId }: BreadOperationContextOptions<TAuth>) {
     this.state = state;
-    this.client = client;
     this.auth = auth;
     this.breadId = breadId;
 
@@ -53,10 +36,4 @@ export class BreadOperationContext<
         : await this.auth.authorizeHttp(this.breadId, requestConfig)
     );
   }
-
-  async invoke<O extends TOperation>(input: O['input']): Promise<O['output']> {
-    return this.client.invoke<O>(input);
-  }
-
-  // TODO: add graphql and other options
 }

--- a/packages/core/src/lib/operation/bread-operation.ts
+++ b/packages/core/src/lib/operation/bread-operation.ts
@@ -20,7 +20,7 @@ import {
 } from './bread-operation-output';
 import { BreadOperationPaginationType } from './bread-operation-pagination';
 
-export interface BreadStandardOperation<T extends string> {
+export interface BreadStandardOperation<T extends string, E = any> {
   name: T;
   input:
     | BreadOperationInput<T>
@@ -36,6 +36,8 @@ export interface BreadStandardOperation<T extends string> {
     | BreadOperationOutputWithRawData<T, object>
     | BreadOperationOutputWithPayload<T, BreadSchema>
     | BreadOperationOutputWithRawDataAndPayload<T, object, BreadSchema>;
+
+  error: E;
 }
 
 // ------------------------------------
@@ -45,10 +47,11 @@ export interface BreadStandardOperation<T extends string> {
 // then it should use specific interfaces designed for that.
 // ------------------------------------
 
-export interface BreadCollectionOperation<
+export type BreadCollectionOperation<
   T extends string,
-  P extends BreadOperationPaginationType
-> {
+  P extends BreadOperationPaginationType,
+  E = any
+> = {
   name: T;
   input:
     | BreadCollectionOperationInput<T, P>
@@ -73,8 +76,10 @@ export interface BreadCollectionOperation<
         BreadSchema[],
         P
       >;
-}
 
-export type BreadOperation<T extends string> =
-  | BreadStandardOperation<T>
-  | BreadCollectionOperation<T, BreadOperationPaginationType>;
+  error: E;
+};
+
+export type BreadOperation<T extends string, E = any> =
+  | BreadStandardOperation<T, E>
+  | BreadCollectionOperation<T, BreadOperationPaginationType, E>;

--- a/packages/core/src/lib/transport/http/bread-http.transport-error.ts
+++ b/packages/core/src/lib/transport/http/bread-http.transport-error.ts
@@ -1,0 +1,3 @@
+import type { AxiosError } from 'axios';
+
+export type BreadHttpTransportError<TResponseData> = AxiosError<TResponseData>;

--- a/packages/core/src/lib/transport/http/bread-http.transport.ts
+++ b/packages/core/src/lib/transport/http/bread-http.transport.ts
@@ -4,26 +4,47 @@ import {
   type AxiosResponse,
   isAxiosError,
 } from 'axios';
+import type { BreadHttpTransportError } from './bread-http.transport-error';
 
 export class BreadHttpTransport {
   static isTooManyRequestsError(error: unknown): boolean {
-    return isAxiosError(error) && error.response?.status === 429;
+    return isAxiosError(error) && this.getErrorStatus(error) === 429;
   }
 
   static isGatewayTimeoutError(error: unknown): boolean {
-    return isAxiosError(error) && error.response?.status === 504;
+    return isAxiosError(error) && this.getErrorStatus(error) === 504;
   }
 
   static isUnavailableError(error: unknown): boolean {
-    return isAxiosError(error) && error.response?.status === 503;
+    return isAxiosError(error) && this.getErrorStatus(error) === 503;
   }
 
   static isConflictError(error: unknown): boolean {
-    return isAxiosError(error) && error.response?.status === 409;
+    return isAxiosError(error) && this.getErrorStatus(error) === 409;
   }
 
   static isInternalServerError(error: unknown): boolean {
-    return isAxiosError(error) && error.response?.status === 500;
+    return isAxiosError(error) && this.getErrorStatus(error) === 500;
+  }
+
+  static isHttpError(error: unknown): error is BreadHttpTransportError<any> {
+    return isAxiosError(error);
+  }
+
+  static getErrorStatus(error: BreadHttpTransportError<any>): number {
+    return error.response?.status ?? error.status ?? 500;
+  }
+
+  static getErrorData<T extends BreadHttpTransportError<any>>(
+    error: T
+  ): T extends BreadHttpTransportError<infer TData>
+    ? TData | undefined
+    : never {
+    return error.response?.data;
+  }
+
+  static getErrorMessage(error: BreadHttpTransportError<any>): string {
+    return error.message;
   }
 
   async request<T>(

--- a/packages/core/src/lib/transport/http/index.ts
+++ b/packages/core/src/lib/transport/http/index.ts
@@ -1,1 +1,2 @@
-export { BreadHttpTransport } from './bread-http.transport';
+export * from './bread-http.transport';
+export * from './bread-http.transport-error';

--- a/packages/data-adapter/jest.config.ts
+++ b/packages/data-adapter/jest.config.ts
@@ -13,6 +13,10 @@ if (swcJestConfig.swcrc === undefined) {
   swcJestConfig.swcrc = false;
 }
 
+if (swcJestConfig !== undefined) {
+  swcJestConfig.sourceMaps = 'inline';
+}
+
 // Uncomment if using global setup/teardown files being transformed via swc
 // https://nx.dev/nx-api/jest/documents/overview#global-setupteardown-with-nx-libraries
 // jest needs EsModule Interop to find the default exported setup/teardown functions

--- a/packages/data-mapper/jest.config.ts
+++ b/packages/data-mapper/jest.config.ts
@@ -13,6 +13,10 @@ if (swcJestConfig.swcrc === undefined) {
   swcJestConfig.swcrc = false;
 }
 
+if (swcJestConfig !== undefined) {
+  swcJestConfig.sourceMaps = 'inline';
+}
+
 // Uncomment if using global setup/teardown files being transformed via swc
 // https://nx.dev/nx-api/jest/documents/overview#global-setupteardown-with-nx-libraries
 // jest needs EsModule Interop to find the default exported setup/teardown functions

--- a/packages/operations/jest.config.ts
+++ b/packages/operations/jest.config.ts
@@ -13,6 +13,10 @@ if (swcJestConfig.swcrc === undefined) {
   swcJestConfig.swcrc = false;
 }
 
+if (swcJestConfig !== undefined) {
+  swcJestConfig.sourceMaps = 'inline';
+}
+
 // Uncomment if using global setup/teardown files being transformed via swc
 // https://nx.dev/nx-api/jest/documents/overview#global-setupteardown-with-nx-libraries
 // jest needs EsModule Interop to find the default exported setup/teardown functions

--- a/packages/pagination-adapter/jest.config.ts
+++ b/packages/pagination-adapter/jest.config.ts
@@ -13,6 +13,10 @@ if (swcJestConfig.swcrc === undefined) {
   swcJestConfig.swcrc = false;
 }
 
+if (swcJestConfig !== undefined) {
+  swcJestConfig.sourceMaps = 'inline';
+}
+
 // Uncomment if using global setup/teardown files being transformed via swc
 // https://nx.dev/nx-api/jest/documents/overview#global-setupteardown-with-nx-libraries
 // jest needs EsModule Interop to find the default exported setup/teardown functions

--- a/packages/schemas/jest.config.ts
+++ b/packages/schemas/jest.config.ts
@@ -13,6 +13,10 @@ if (swcJestConfig.swcrc === undefined) {
   swcJestConfig.swcrc = false;
 }
 
+if (swcJestConfig !== undefined) {
+  swcJestConfig.sourceMaps = 'inline';
+}
+
 // Uncomment if using global setup/teardown files being transformed via swc
 // https://nx.dev/nx-api/jest/documents/overview#global-setupteardown-with-nx-libraries
 // jest needs EsModule Interop to find the default exported setup/teardown functions

--- a/packages/service-adapters/bamboo-hr/jest.config.ts
+++ b/packages/service-adapters/bamboo-hr/jest.config.ts
@@ -13,6 +13,10 @@ if (swcJestConfig.swcrc === undefined) {
   swcJestConfig.swcrc = false;
 }
 
+if (swcJestConfig !== undefined) {
+  swcJestConfig.sourceMaps = 'inline';
+}
+
 // Uncomment if using global setup/teardown files being transformed via swc
 // https://nx.dev/nx-api/jest/documents/overview#global-setupteardown-with-nx-libraries
 // jest needs EsModule Interop to find the default exported setup/teardown functions

--- a/packages/service-adapters/bamboo-hr/src/lib/__mocks__/axios.ts
+++ b/packages/service-adapters/bamboo-hr/src/lib/__mocks__/axios.ts
@@ -1,6 +1,0 @@
-const axios = jest.requireActual('axios');
-
-module.exports = {
-  ...axios,
-  request: jest.fn(() => Promise.resolve({ status: 500 })),
-};

--- a/packages/service-adapters/bamboo-hr/src/lib/__tests__/bamboo.spec.ts
+++ b/packages/service-adapters/bamboo-hr/src/lib/__tests__/bamboo.spec.ts
@@ -361,6 +361,7 @@ describe('usage', () => {
         provider: 'bamboo',
         rawPayload: {
           error: {
+            name: 'ServiceException',
             message:
               'bamboo: Request failed with status code 409. Duplicate email',
             originalError: {

--- a/packages/service-adapters/bamboo-hr/src/lib/handlers/bamboo.employee-by-id.handler.ts
+++ b/packages/service-adapters/bamboo-hr/src/lib/handlers/bamboo.employee-by-id.handler.ts
@@ -2,17 +2,15 @@ import {
   BreadOperationHandler,
   createSuccessfulOutputWithRawDataAndPayload,
 } from '@easybread/core';
-import {
-  BreadOperationName,
-  EmployeeByIdOperation,
-} from '@easybread/operations';
+import { BreadOperationName } from '@easybread/operations';
 
 import { BambooHrAuthStrategy } from '../bamboo-hr.auth-strategy';
 import { BambooEmployee } from '../interfaces';
 import { bambooEmployeeAdapter } from '../data-adapters';
+import type { BambooHrEmployeeByIdOperation } from '../bamboo-hr.operation';
 
 export const BambooEmployeeByIdHandler: BreadOperationHandler<
-  EmployeeByIdOperation<BambooEmployee>,
+  BambooHrEmployeeByIdOperation,
   BambooHrAuthStrategy
 > = {
   name: BreadOperationName.EMPLOYEE_BY_ID,

--- a/packages/service-adapters/bamboo-hr/src/lib/handlers/bamboo.employee-create.handler.ts
+++ b/packages/service-adapters/bamboo-hr/src/lib/handlers/bamboo.employee-create.handler.ts
@@ -2,17 +2,15 @@ import {
   BreadOperationHandler,
   createSuccessfulOutputWithRawDataAndPayload,
 } from '@easybread/core';
-import {
-  BreadOperationName,
-  EmployeeCreateOperation,
-} from '@easybread/operations';
+import { BreadOperationName } from '@easybread/operations';
 import { AxiosResponse } from 'axios';
 
 import { BambooHrAuthStrategy } from '../bamboo-hr.auth-strategy';
 import { bambooEmployeeAdapter } from '../data-adapters';
+import type { BambooHrEmployeeCreateOperation } from '../bamboo-hr.operation';
 
 export const BambooEmployeeCreateHandler: BreadOperationHandler<
-  EmployeeCreateOperation,
+  BambooHrEmployeeCreateOperation,
   BambooHrAuthStrategy
 > = {
   name: BreadOperationName.EMPLOYEE_CREATE,

--- a/packages/service-adapters/bamboo-hr/src/lib/handlers/bamboo.employee-search.handler.ts
+++ b/packages/service-adapters/bamboo-hr/src/lib/handlers/bamboo.employee-search.handler.ts
@@ -3,19 +3,17 @@ import {
   createDisabledPagination,
   createSuccessfulCollectionOutputWithRawDataAndPayload,
 } from '@easybread/core';
-import {
-  BreadOperationName,
-  EmployeeSearchOperation,
-} from '@easybread/operations';
+import { BreadOperationName } from '@easybread/operations';
 import { OrganizationSchema, PersonSchema } from '@easybread/schemas';
 import { find, isNumber, isObject, isString, pick } from 'lodash';
 
 import { BambooHrAuthStrategy } from '../bamboo-hr.auth-strategy';
 import { bambooEmployeeAdapter } from '../data-adapters';
 import { BambooEmployeesDirectory } from '../interfaces';
+import type { BambooHrEmployeeSearchOperation } from '../bamboo-hr.operation';
 
 export const BambooEmployeeSearchHandler: BreadOperationHandler<
-  EmployeeSearchOperation<BambooEmployeesDirectory>,
+  BambooHrEmployeeSearchOperation,
   BambooHrAuthStrategy
 > = {
   name: BreadOperationName.EMPLOYEE_SEARCH,

--- a/packages/service-adapters/bamboo-hr/src/lib/handlers/bamboo.employee-update.handler.ts
+++ b/packages/service-adapters/bamboo-hr/src/lib/handlers/bamboo.employee-update.handler.ts
@@ -2,16 +2,14 @@ import {
   BreadOperationHandler,
   createSuccessfulOutputWithRawDataAndPayload,
 } from '@easybread/core';
-import {
-  BreadOperationName,
-  EmployeeUpdateOperation,
-} from '@easybread/operations';
+import { BreadOperationName } from '@easybread/operations';
 
 import { BambooHrAuthStrategy } from '../bamboo-hr.auth-strategy';
 import { bambooEmployeeAdapter } from '../data-adapters';
+import type { BambooHrEmployeeUpdateOperation } from '../bamboo-hr.operation';
 
 export const BambooEmployeeUpdateHandler: BreadOperationHandler<
-  EmployeeUpdateOperation,
+  BambooHrEmployeeUpdateOperation,
   BambooHrAuthStrategy
 > = {
   async handle(input, context) {

--- a/packages/service-adapters/bamboo-hr/src/lib/handlers/bamboo.setup-basic-auth.handler.ts
+++ b/packages/service-adapters/bamboo-hr/src/lib/handlers/bamboo.setup-basic-auth.handler.ts
@@ -1,14 +1,11 @@
 import { BreadOperationHandler, createSuccessfulOutput } from '@easybread/core';
-import {
-  BreadOperationName,
-  SetupBasicAuthOperation,
-} from '@easybread/operations';
+import { BreadOperationName } from '@easybread/operations';
 
 import { BambooHrAuthStrategy } from '../bamboo-hr.auth-strategy';
-import { BambooBasicAuthPayload } from '../interfaces';
+import type { BambooHrSetupBasicAuthOperation } from '../bamboo-hr.operation';
 
 export const BambooSetupBasicAuthHandler: BreadOperationHandler<
-  SetupBasicAuthOperation<BambooBasicAuthPayload>,
+  BambooHrSetupBasicAuthOperation,
   BambooHrAuthStrategy
 > = {
   name: BreadOperationName.SETUP_BASIC_AUTH,

--- a/packages/service-adapters/breezy/jest.config.ts
+++ b/packages/service-adapters/breezy/jest.config.ts
@@ -13,6 +13,10 @@ if (swcJestConfig.swcrc === undefined) {
   swcJestConfig.swcrc = false;
 }
 
+if (swcJestConfig !== undefined) {
+  swcJestConfig.sourceMaps = 'inline';
+}
+
 // Uncomment if using global setup/teardown files being transformed via swc
 // https://nx.dev/nx-api/jest/documents/overview#global-setupteardown-with-nx-libraries
 // jest needs EsModule Interop to find the default exported setup/teardown functions

--- a/packages/service-adapters/breezy/package.json
+++ b/packages/service-adapters/breezy/package.json
@@ -5,7 +5,8 @@
     "@easybread/core": "0.0.1",
     "@easybread/schemas": "0.0.1",
     "axios": "^1.7.4",
-    "@easybread/data-adapter": "0.0.1"
+    "@easybread/data-adapter": "0.0.1",
+    "@easybread/test-utils": "0.0.1"
   },
   "main": "./index.cjs",
   "module": "./index.js"

--- a/packages/service-adapters/breezy/src/lib/__mocks__/axios.ts
+++ b/packages/service-adapters/breezy/src/lib/__mocks__/axios.ts
@@ -1,6 +1,0 @@
-const axios = jest.requireActual('axios');
-
-module.exports = {
-  ...axios,
-  request: jest.fn(() => Promise.resolve({ status: 500 })),
-};

--- a/packages/service-adapters/breezy/src/lib/__tests__/breezy.spec.ts
+++ b/packages/service-adapters/breezy/src/lib/__tests__/breezy.spec.ts
@@ -15,8 +15,9 @@ import {
   SIGN_IN_RESPONSE_MOCK,
   USER_ID,
 } from './mocks';
+import { mockAxios } from '@easybread/test-utils';
 
-jest.mock('axios');
+mockAxios();
 
 describe('Breezy', () => {
   const breezyAdapter = new BreezyAdapter();

--- a/packages/service-adapters/google/admin-directory/jest.config.ts
+++ b/packages/service-adapters/google/admin-directory/jest.config.ts
@@ -13,6 +13,10 @@ if (swcJestConfig.swcrc === undefined) {
   swcJestConfig.swcrc = false;
 }
 
+if (swcJestConfig !== undefined) {
+  swcJestConfig.sourceMaps = 'inline';
+}
+
 // Uncomment if using global setup/teardown files being transformed via swc
 // https://nx.dev/nx-api/jest/documents/overview#global-setupteardown-with-nx-libraries
 // jest needs EsModule Interop to find the default exported setup/teardown functions

--- a/packages/service-adapters/google/admin-directory/src/lib/__mocks__/axios.ts
+++ b/packages/service-adapters/google/admin-directory/src/lib/__mocks__/axios.ts
@@ -1,6 +1,0 @@
-const axios = jest.requireActual('axios');
-
-module.exports = {
-  ...axios,
-  request: jest.fn(() => Promise.resolve({ status: 500 })),
-};

--- a/packages/service-adapters/google/admin-directory/src/lib/__tests__/adapter-google-admin-directory.spec.ts
+++ b/packages/service-adapters/google/admin-directory/src/lib/__tests__/adapter-google-admin-directory.spec.ts
@@ -7,7 +7,7 @@ import {
 } from '@easybread/adapter-google-common';
 import { PersonSchema } from '@easybread/schemas';
 import { mockAxios, setExtendedTimeout } from '@easybread/test-utils';
-import axiosMock from 'axios';
+import axios from 'axios';
 import { merge } from 'lodash';
 
 import {
@@ -25,8 +25,6 @@ import {
 } from '../..';
 import { USERS_BY_ID_MOCK } from './users-by-id.mock';
 import { USERS_LIST_MOCK } from './users-list.mock';
-
-type Mock = jest.Mock;
 
 const BREAD_ID = '1';
 const CLIENT_ID = 'client-id';
@@ -100,7 +98,7 @@ describe('Operations', () => {
 
     it(`should call google /token api`, async () => {
       await invokeCompleteAuth();
-      expect(axiosMock.request).toHaveBeenCalledWith({
+      expect(axios.request).toHaveBeenCalledWith({
         url: 'https://oauth2.googleapis.com/token',
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -117,7 +115,7 @@ describe('Operations', () => {
   describe(GoogleAdminDirectoryOperationName.USERS_SEARCH, () => {
     it(`should call GET https://www.googleapis.com/admin/directory/v1/users`, async () => {
       await invokeUsersSearch('searchterm');
-      expect(axiosMock.request).toHaveBeenCalledWith({
+      expect(axios.request).toHaveBeenCalledWith({
         method: 'GET',
         url: 'https://www.googleapis.com/admin/directory/v1/users',
         headers: { authorization: 'Bearer access-token' },
@@ -171,7 +169,7 @@ describe('Operations', () => {
   describe(GoogleAdminDirectoryOperationName.USERS_BY_ID, () => {
     it(`should call GET https://www.googleapis.com/admin/directory/v1/users`, async () => {
       await invokeUsersById('114190879825460327746');
-      expect(axiosMock.request).toHaveBeenCalledWith({
+      expect(axios.request).toHaveBeenCalledWith({
         method: 'GET',
         url: 'https://www.googleapis.com/admin/directory/v1/users/114190879825460327746',
         headers: { authorization: 'Bearer access-token' },
@@ -210,7 +208,7 @@ describe('Operations', () => {
         givenName: 'updated',
       });
 
-      expect(axiosMock.request).toHaveBeenCalledWith({
+      expect(axios.request).toHaveBeenCalledWith({
         method: 'PUT',
         url: 'https://www.googleapis.com/admin/directory/v1/users/114190879825460327746',
         headers: { authorization: 'Bearer access-token' },
@@ -264,7 +262,7 @@ describe('Operations', () => {
         givenName: 'Test',
         familyName: 'Test',
       });
-      expect(axiosMock.request).toHaveBeenCalledWith({
+      expect(axios.request).toHaveBeenCalledWith({
         data: {
           kind: 'admin#directory#user',
           name: { familyName: 'Test', givenName: 'Test' },
@@ -311,7 +309,7 @@ describe('Operations', () => {
     it(`should call DELETE https://www.googleapis.com/admin/directory/v1/users/userKey`, async () => {
       const id = '114190879825460327746';
       await invokeUsersDelete(id);
-      expect(axiosMock.request).toHaveBeenCalledWith({
+      expect(axios.request).toHaveBeenCalledWith({
         headers: { authorization: 'Bearer access-token' },
         method: 'DELETE',
         url: `https://www.googleapis.com/admin/directory/v1/users/${id}`,
@@ -413,7 +411,7 @@ async function invokeCompleteAuth(): Promise<
 // ------------------------------------
 
 function setupUsersSearchResponse(): void {
-  (axiosMock.request as Mock).mockImplementationOnce(() =>
+  jest.mocked(axios.request).mockImplementationOnce(() =>
     Promise.resolve({
       status: 200,
       data: USERS_LIST_MOCK,
@@ -422,7 +420,7 @@ function setupUsersSearchResponse(): void {
 }
 
 function setupUsersByIdResponse(): void {
-  (axiosMock.request as Mock).mockImplementationOnce(() =>
+  jest.mocked(axios.request).mockImplementationOnce(() =>
     Promise.resolve({
       status: 200,
       data: USERS_BY_ID_MOCK,
@@ -435,7 +433,7 @@ function setupUsersUpdateResponse(
 ): GoogleAdminDirectoryUser {
   const updatedData = merge({}, USERS_BY_ID_MOCK, update);
 
-  (axiosMock.request as Mock).mockImplementationOnce(() =>
+  jest.mocked(axios.request).mockImplementationOnce(() =>
     Promise.resolve({
       status: 200,
       data: updatedData,
@@ -446,7 +444,7 @@ function setupUsersUpdateResponse(
 }
 
 function setupUsersCreateResponse(): void {
-  (axiosMock.request as Mock).mockImplementationOnce(() =>
+  jest.mocked(axios.request).mockImplementationOnce(() =>
     Promise.resolve({
       status: 200,
       data: USERS_BY_ID_MOCK,
@@ -455,7 +453,7 @@ function setupUsersCreateResponse(): void {
 }
 
 function setupUsersDeleteResponse(): void {
-  (axiosMock.request as Mock).mockImplementationOnce(() =>
+  jest.mocked(axios.request).mockImplementationOnce(() =>
     Promise.resolve({
       status: 200,
       data: '',
@@ -464,7 +462,7 @@ function setupUsersDeleteResponse(): void {
 }
 
 function setupAccessTokenCreateResponse(): void {
-  (axiosMock.request as Mock).mockImplementationOnce(() =>
+  jest.mocked(axios.request).mockImplementationOnce(() =>
     Promise.resolve({
       status: 200,
       data: ACCESS_TOKEN_CREATE_RESPONSE_DATA,

--- a/packages/service-adapters/google/admin-directory/src/lib/handlers/google-admin-directory.users-search.handler.ts
+++ b/packages/service-adapters/google/admin-directory/src/lib/handlers/google-admin-directory.users-search.handler.ts
@@ -1,4 +1,5 @@
 import {
+  BreadHttpTransport,
   BreadOperationHandler,
   createSuccessfulCollectionOutputWithRawDataAndPayload,
 } from '@easybread/core';
@@ -44,5 +45,6 @@ export const GoogleAdminDirectoryUsersSearchHandler: BreadOperationHandler<
       googleAdminDirectoryPaginationAdapter.toInternalData(response.data)
     );
   },
+
   name: GoogleAdminDirectoryOperationName.USERS_SEARCH,
 };

--- a/packages/service-adapters/google/admin-directory/src/lib/handlers/google-admin-directory.users-update.handler.ts
+++ b/packages/service-adapters/google/admin-directory/src/lib/handlers/google-admin-directory.users-update.handler.ts
@@ -4,10 +4,10 @@ import {
 } from '@easybread/core';
 
 import { googleAdminDirectoryUserAdapter } from '../data-adapters';
-import { GoogleAdminDirectoryAuthStrategy } from '../google-admin-directory.auth-strategy';
 import { GoogleAdminDirectoryOperationName } from '../google-admin-directory.operation-name';
 import { GoogleAdminDirectoryUser } from '../interfaces';
 import { GoogleAdminDirectoryUsersUpdateOperation } from '../operations';
+import type { GoogleAdminDirectoryAuthStrategy } from '../google-admin-directory.auth-strategy';
 
 export const GoogleAdminDirectoryUsersUpdateHandler: BreadOperationHandler<
   GoogleAdminDirectoryUsersUpdateOperation,

--- a/packages/service-adapters/google/common/jest.config.ts
+++ b/packages/service-adapters/google/common/jest.config.ts
@@ -13,6 +13,10 @@ if (swcJestConfig.swcrc === undefined) {
   swcJestConfig.swcrc = false;
 }
 
+if (swcJestConfig !== undefined) {
+  swcJestConfig.sourceMaps = 'inline';
+}
+
 // Uncomment if using global setup/teardown files being transformed via swc
 // https://nx.dev/nx-api/jest/documents/overview#global-setupteardown-with-nx-libraries
 // jest needs EsModule Interop to find the default exported setup/teardown functions

--- a/packages/service-adapters/google/common/src/lib/__mocks__/axios.ts
+++ b/packages/service-adapters/google/common/src/lib/__mocks__/axios.ts
@@ -1,6 +1,0 @@
-const axios = jest.requireActual('axios');
-
-module.exports = {
-  ...axios,
-  request: jest.fn(() => Promise.resolve({ status: 500 })),
-};

--- a/packages/service-adapters/google/common/src/lib/__tests__/create-context-mock.ts
+++ b/packages/service-adapters/google/common/src/lib/__tests__/create-context-mock.ts
@@ -1,10 +1,8 @@
-import { BreadOperation, BreadOperationContext } from '@easybread/core';
+import { BreadOperationContext } from '@easybread/core';
 
 import { GoogleCommonOauth2AuthStrategy } from '../google-common.oauth2.auth-strategy';
 
-export function createContextMock<
-  TOperation extends BreadOperation<string>
->(): BreadOperationContext<TOperation, GoogleCommonOauth2AuthStrategy> {
+export function createContextMock(): BreadOperationContext<GoogleCommonOauth2AuthStrategy> {
   const auth = {
     authenticate: jest.fn(),
     createAuthUri: jest.fn(),
@@ -12,8 +10,5 @@ export function createContextMock<
 
   // trick typescript
   const context = { auth } as unknown;
-  return context as BreadOperationContext<
-    TOperation,
-    GoogleCommonOauth2AuthStrategy
-  >;
+  return context as BreadOperationContext<GoogleCommonOauth2AuthStrategy>;
 }

--- a/packages/service-adapters/google/common/src/lib/__tests__/google-common.oauth2-complete.handler.spec.ts
+++ b/packages/service-adapters/google/common/src/lib/__tests__/google-common.oauth2-complete.handler.spec.ts
@@ -1,8 +1,5 @@
 import { GoogleCommonOauth2CompleteHandler } from '../handlers';
-import {
-  GoogleCommonOauth2CompleteOperation,
-  GoogleCommonOperationName,
-} from '../operations';
+import { GoogleCommonOperationName } from '../operations';
 import { createContextMock } from './create-context-mock';
 
 describe('name', () => {
@@ -15,7 +12,7 @@ describe('name', () => {
 
 describe('handle', () => {
   it(`should call context.auth.authenticate`, async () => {
-    const context = createContextMock<GoogleCommonOauth2CompleteOperation>();
+    const context = createContextMock();
     await GoogleCommonOauth2CompleteHandler.handle(
       {
         payload: { code: '123' },
@@ -32,7 +29,7 @@ describe('handle', () => {
   });
 
   it(`should produce correct output with auth data in raw payload`, async () => {
-    const context = createContextMock<GoogleCommonOauth2CompleteOperation>();
+    const context = createContextMock();
 
     (context.auth.authenticate as jest.Mock).mockImplementationOnce(() => {
       return { foo: 'bar' };

--- a/packages/service-adapters/google/common/src/lib/__tests__/google-common.oauth2-start.handler.spec.ts
+++ b/packages/service-adapters/google/common/src/lib/__tests__/google-common.oauth2-start.handler.spec.ts
@@ -1,8 +1,5 @@
 import { GoogleCommonOauth2StartHandler } from '../handlers';
-import {
-  GoogleCommonOauth2StartOperation,
-  GoogleCommonOperationName,
-} from '../operations';
+import { GoogleCommonOperationName } from '../operations';
 import { createContextMock } from './create-context-mock';
 
 describe('name', () => {
@@ -15,7 +12,7 @@ describe('name', () => {
 
 describe('handle()', () => {
   it(`should call context.auth.createAuthUri()`, () => {
-    const context = createContextMock<GoogleCommonOauth2StartOperation>();
+    const context = createContextMock();
     GoogleCommonOauth2StartHandler.handle(
       {
         name: GoogleCommonOperationName.AUTH_FLOW_START,
@@ -41,11 +38,11 @@ describe('handle()', () => {
   });
 
   it(`should produce correct output with authUrl in raw payload `, async () => {
-    const context = createContextMock<GoogleCommonOauth2StartOperation>();
+    const context = createContextMock();
 
-    (context.auth.createAuthUri as jest.Mock).mockImplementationOnce(
-      () => 'http://authurl'
-    );
+    jest
+      .mocked(context.auth.createAuthUri)
+      .mockImplementationOnce(async () => 'http://authurl');
 
     const output = await GoogleCommonOauth2StartHandler.handle(
       {

--- a/packages/service-adapters/google/common/src/lib/__tests__/google-common.oauth2.auth-strategy.spec.ts
+++ b/packages/service-adapters/google/common/src/lib/__tests__/google-common.oauth2.auth-strategy.spec.ts
@@ -4,15 +4,13 @@ import {
   mockAxios,
   setExtendedTimeout,
 } from '@easybread/test-utils';
-import axiosMock from 'axios';
+import axios from 'axios';
 
 import {
   GoogleCommonOauth2AuthStrategy,
   GoogleCommonAccessTokenCreateResponse,
   GoogleCommonAccessTokenRefreshResponse,
 } from '../..';
-
-type Mock = jest.Mock;
 
 type TestScopes =
   | 'https://www.google.com/m8/feeds/'
@@ -104,7 +102,7 @@ describe('authenticate()', () => {
 
   it(`should send correct http request`, async () => {
     await authStrategy.authenticate(BREAD_ID, { code: 'testcode' });
-    expect(axiosMock.request).toHaveBeenCalledWith({
+    expect(axios.request).toHaveBeenCalledWith({
       data:
         'client_id=TEST_ID' +
         '&client_secret=TEST_SECRET' +
@@ -181,7 +179,7 @@ describe('refreshToken()', () => {
     jest.resetAllMocks();
     setupRefreshTokenMock();
     await authStrategy.refreshToken(BREAD_ID);
-    expect(axiosMock.request).toHaveBeenCalledWith({
+    expect(axios.request).toHaveBeenCalledWith({
       data:
         'client_id=TEST_ID' +
         '&client_secret=TEST_SECRET' +
@@ -197,7 +195,7 @@ describe('refreshToken()', () => {
 //  ------------------------------------
 
 function setupAccessTokenResponseMock(): void {
-  (axiosMock.request as Mock).mockImplementationOnce(() => {
+  jest.mocked(axios.request).mockImplementationOnce(() => {
     return Promise.resolve({
       status: 200,
       data: ACCESS_TOKEN_CREATE_RESPONSE_DATA,
@@ -206,7 +204,7 @@ function setupAccessTokenResponseMock(): void {
 }
 
 function setupRefreshTokenMock(): void {
-  (axiosMock.request as Mock).mockImplementationOnce(() => {
+  jest.mocked(axios.request).mockImplementationOnce(() => {
     return Promise.resolve({
       status: 200,
       data: REFRESH_TOKEN_RESPONSE_DATA,

--- a/packages/service-adapters/google/contacts/jest.config.ts
+++ b/packages/service-adapters/google/contacts/jest.config.ts
@@ -13,6 +13,10 @@ if (swcJestConfig.swcrc === undefined) {
   swcJestConfig.swcrc = false;
 }
 
+if (swcJestConfig !== undefined) {
+  swcJestConfig.sourceMaps = 'inline';
+}
+
 // Uncomment if using global setup/teardown files being transformed via swc
 // https://nx.dev/nx-api/jest/documents/overview#global-setupteardown-with-nx-libraries
 // jest needs EsModule Interop to find the default exported setup/teardown functions

--- a/packages/service-adapters/google/contacts/src/lib/__mocks__/axios.ts
+++ b/packages/service-adapters/google/contacts/src/lib/__mocks__/axios.ts
@@ -1,6 +1,0 @@
-const axios = jest.requireActual('axios');
-
-module.exports = {
-  ...axios,
-  request: jest.fn(() => Promise.resolve({ status: 500 })),
-};

--- a/packages/service-adapters/rocket-chat/common/jest.config.ts
+++ b/packages/service-adapters/rocket-chat/common/jest.config.ts
@@ -13,6 +13,10 @@ if (swcJestConfig.swcrc === undefined) {
   swcJestConfig.swcrc = false;
 }
 
+if (swcJestConfig !== undefined) {
+  swcJestConfig.sourceMaps = 'inline';
+}
+
 // Uncomment if using global setup/teardown files being transformed via swc
 // https://nx.dev/nx-api/jest/documents/overview#global-setupteardown-with-nx-libraries
 // jest needs EsModule Interop to find the default exported setup/teardown functions

--- a/packages/service-adapters/rocket-chat/common/src/lib/__mocks__/axios.ts
+++ b/packages/service-adapters/rocket-chat/common/src/lib/__mocks__/axios.ts
@@ -1,6 +1,0 @@
-const axios = jest.requireActual('axios');
-
-module.exports = {
-  ...axios,
-  request: jest.fn(() => Promise.resolve({ status: 500 })),
-};

--- a/packages/service-adapters/rocket-chat/common/src/lib/__tests__/rocket-chat.auth-configure.handler.spec.ts
+++ b/packages/service-adapters/rocket-chat/common/src/lib/__tests__/rocket-chat.auth-configure.handler.spec.ts
@@ -3,10 +3,8 @@ import { createContextMock } from '@easybread/test-utils';
 
 import {
   RocketChatAuthConfigureHandler,
-  RocketChatAuthConfigureOperation,
   RocketChatAuthStrategy,
   RocketChatOperationName,
-  RocketChatServiceAdapterOptions,
 } from '../..';
 
 afterAll(() => {
@@ -15,13 +13,7 @@ afterAll(() => {
 
 it(`should call RocketChatAuthStrategy.authenticate with token and user id`, async () => {
   const context =
-    createContextMock<
-      BreadOperationContext<
-        RocketChatAuthConfigureOperation,
-        RocketChatAuthStrategy,
-        RocketChatServiceAdapterOptions
-      >
-    >();
+    createContextMock<BreadOperationContext<RocketChatAuthStrategy>>();
 
   await RocketChatAuthConfigureHandler.handle(
     {

--- a/packages/service-adapters/rocket-chat/users/jest.config.ts
+++ b/packages/service-adapters/rocket-chat/users/jest.config.ts
@@ -13,6 +13,10 @@ if (swcJestConfig.swcrc === undefined) {
   swcJestConfig.swcrc = false;
 }
 
+if (swcJestConfig !== undefined) {
+  swcJestConfig.sourceMaps = 'inline';
+}
+
 // Uncomment if using global setup/teardown files being transformed via swc
 // https://nx.dev/nx-api/jest/documents/overview#global-setupteardown-with-nx-libraries
 // jest needs EsModule Interop to find the default exported setup/teardown functions

--- a/packages/service-adapters/rocket-chat/users/package.json
+++ b/packages/service-adapters/rocket-chat/users/package.json
@@ -5,7 +5,8 @@
     "@easybread/core": "0.0.1",
     "@easybread/schemas": "0.0.1",
     "axios": "^1.7.4",
-    "@easybread/adapter-rocket-chat-common": "0.0.1"
+    "@easybread/adapter-rocket-chat-common": "0.0.1",
+    "@easybread/test-utils": "0.0.1"
   },
   "main": "./index.cjs",
   "module": "./index.js"

--- a/packages/service-adapters/rocket-chat/users/src/lib/__mocks__/axios.ts
+++ b/packages/service-adapters/rocket-chat/users/src/lib/__mocks__/axios.ts
@@ -1,6 +1,0 @@
-const axios = jest.requireActual('axios');
-
-module.exports = {
-  ...axios,
-  request: jest.fn(() => Promise.resolve({ status: 500 })),
-};

--- a/packages/service-adapters/rocket-chat/users/src/lib/__tests__/adapter-rocket-chat-users.spec.ts
+++ b/packages/service-adapters/rocket-chat/users/src/lib/__tests__/adapter-rocket-chat-users.spec.ts
@@ -1,15 +1,16 @@
+import axios from 'axios';
+import { mockAxios } from '@easybread/test-utils';
 import {
   BreadOperationSkipCountInputPagination,
   EasyBreadClient,
   InMemoryStateAdapter,
 } from '@easybread/core';
+
 import {
   RocketChatAuthConfigureOperation,
   RocketChatAuthStrategy,
   RocketChatOperationName,
 } from '@easybread/adapter-rocket-chat-common';
-import axiosMock from 'axios';
-
 import {
   RocketChatUsersAdapter,
   RocketChatUsersByIdOperation,
@@ -20,6 +21,8 @@ import {
 } from '../..';
 import { USERS_INFO_MOCK } from './users-info.mock';
 import { USERS_LIST_MOCK } from './users-list.mock';
+
+mockAxios();
 
 const BREAD_ID = '1';
 const AUTH_TOKEN = 'auth-token';
@@ -60,7 +63,7 @@ describe('Operations', () => {
 
     it(`should call GET https://testserver.io/api/users.list with expected query params`, async () => {
       await invokeUsersSearch();
-      expect((axiosMock.request as jest.Mock).mock.calls).toEqual([
+      expect(jest.mocked(axios.request).mock.calls).toEqual([
         [
           {
             headers: { 'X-Auth-Token': AUTH_TOKEN, 'X-User-Id': USER_ID },
@@ -118,7 +121,7 @@ describe('Operations', () => {
 
     it(`should call GET https://testserver.io/api/users.info with expected query params`, async () => {
       await invokeUsersById({ identifier: 'id1' });
-      expect(jest.mocked(axiosMock.request).mock.calls).toEqual([
+      expect(jest.mocked(axios.request).mock.calls).toEqual([
         [
           {
             headers: { 'X-Auth-Token': AUTH_TOKEN, 'X-User-Id': USER_ID },
@@ -152,7 +155,7 @@ describe('Operations', () => {
 //  ------------------------------------
 
 function setupUsersListResponse(): void {
-  (axiosMock.request as jest.Mock).mockImplementationOnce(() =>
+  jest.mocked(axios.request).mockImplementationOnce(() =>
     Promise.resolve({
       status: 200,
       data: USERS_LIST_MOCK,
@@ -180,7 +183,7 @@ async function invokeUsersSearch(
 //  ------------------------------------
 
 function setupUsersInfoResponse(): void {
-  (axiosMock.request as jest.Mock).mockImplementationOnce(() =>
+  jest.mocked(axios.request).mockImplementationOnce(() =>
     Promise.resolve({
       status: 200,
       data: USERS_INFO_MOCK,

--- a/packages/state-adapter-mongo/jest.config.ts
+++ b/packages/state-adapter-mongo/jest.config.ts
@@ -13,6 +13,10 @@ if (swcJestConfig.swcrc === undefined) {
   swcJestConfig.swcrc = false;
 }
 
+if (swcJestConfig !== undefined) {
+  swcJestConfig.sourceMaps = 'inline';
+}
+
 // Uncomment if using global setup/teardown files being transformed via swc
 // https://nx.dev/nx-api/jest/documents/overview#global-setupteardown-with-nx-libraries
 // jest needs EsModule Interop to find the default exported setup/teardown functions

--- a/packages/test-utils/jest.config.ts
+++ b/packages/test-utils/jest.config.ts
@@ -13,6 +13,10 @@ if (swcJestConfig.swcrc === undefined) {
   swcJestConfig.swcrc = false;
 }
 
+if (swcJestConfig !== undefined) {
+  swcJestConfig.sourceMaps = 'inline';
+}
+
 // Uncomment if using global setup/teardown files being transformed via swc
 // https://nx.dev/nx-api/jest/documents/overview#global-setupteardown-with-nx-libraries
 // jest needs EsModule Interop to find the default exported setup/teardown functions

--- a/packages/test-utils/src/lib/create-axios-error.ts
+++ b/packages/test-utils/src/lib/create-axios-error.ts
@@ -1,8 +1,16 @@
 import { AxiosError, type AxiosResponse } from 'axios';
+type CreateAxiosErrorResponse = Partial<AxiosResponse> & { status: number };
+
+const DEFAULT_RESPONSE = {
+  status: 500,
+  statusText: 'Artificial Test Error',
+  data: {},
+  headers: {},
+} satisfies CreateAxiosErrorResponse;
 
 export function createAxiosError(
   errorMessage: string,
-  response: Partial<AxiosResponse> & { status: number }
+  response: CreateAxiosErrorResponse = { ...DEFAULT_RESPONSE }
 ) {
   return new AxiosError(
     errorMessage,
@@ -11,9 +19,7 @@ export function createAxiosError(
     {},
     {
       config: {} as any,
-      statusText: 'Artificial Test Error',
-      headers: {},
-      data: '',
+      ...DEFAULT_RESPONSE,
       ...response,
     }
   );

--- a/packages/test-utils/src/lib/setup-utils.ts
+++ b/packages/test-utils/src/lib/setup-utils.ts
@@ -1,6 +1,8 @@
+import axios from 'axios';
+
 export const setExtendedTimeout = (): void => {
   jest.setTimeout(1000 * 60 * 5);
 };
 export const mockAxios = (): void => {
-  jest.mock('axios');
+  jest.spyOn(axios, 'request');
 };

--- a/playground/app/app/api/error/route.ts
+++ b/playground/app/app/api/error/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+export async function GET() {
+  return NextResponse.json(
+    {
+      foo: 'bar',
+    },
+    { status: 500 }
+  );
+}

--- a/playground/app/app/layout.tsx
+++ b/playground/app/app/layout.tsx
@@ -11,7 +11,7 @@ export const metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body className="h-screen w-screen bg-zinc-100 amber-100 scrollbar-thin scrollbar-thumb-amber-200 scroll-auto">
+      <body className="h-screen w-screen min-w-[720px] relative bg-zinc-100 amber-100 scrollbar-thin scrollbar-thumb-amber-200 scroll-auto">
         <TopNav />
         <PageContent>{children}</PageContent>
       </body>

--- a/playground/easybread/clients/src/lib/clientBambooHrGet.ts
+++ b/playground/easybread/clients/src/lib/clientBambooHrGet.ts
@@ -1,7 +1,6 @@
 import {
   BambooHrAdapter,
   BambooHrAuthStrategy,
-  type BambooHrOperation,
 } from '@easybread/adapter-bamboo-hr';
 import { stateAdapterMongoGet } from 'playground-easybread-state';
 import { BreadAuthenticationLostEvent, EasyBreadClient } from '@easybread/core';
@@ -9,7 +8,7 @@ import { ADAPTER_NAME, parseBreadId } from 'playground-common';
 import { adapterCollection } from 'playground-db';
 import { revalidatePath } from 'next/cache';
 
-let client: EasyBreadClient<BambooHrOperation, BambooHrAuthStrategy, null>;
+let client: EasyBreadClient<BambooHrAdapter, BambooHrAuthStrategy>;
 
 export async function clientBambooHrGet() {
   if (client) return client;

--- a/playground/easybread/clients/src/lib/clientGoogleAdminDirectoryGet.ts
+++ b/playground/easybread/clients/src/lib/clientGoogleAdminDirectoryGet.ts
@@ -3,7 +3,6 @@ import { stateAdapterMongoGet } from 'playground-easybread-state';
 import {
   GoogleAdminDirectoryAdapter,
   GoogleAdminDirectoryAuthStrategy,
-  type GoogleAdminDirectoryOperation,
 } from '@easybread/adapter-google-admin-directory';
 import { load } from 'ts-dotenv';
 import { ADAPTER_NAME, parseBreadId } from 'playground-common';
@@ -11,9 +10,8 @@ import { adapterCollection } from 'playground-db';
 import { revalidatePath } from 'next/cache';
 
 let client: EasyBreadClient<
-  GoogleAdminDirectoryOperation,
-  GoogleAdminDirectoryAuthStrategy,
-  null
+  GoogleAdminDirectoryAdapter,
+  GoogleAdminDirectoryAuthStrategy
 >;
 
 export const clientGoogleAdminDirectoryGet = async () => {
@@ -47,9 +45,6 @@ export const clientGoogleAdminDirectoryGet = async () => {
   client.subscribe(BreadAuthenticationLostEvent.eventName, async (event) => {
     const { breadId } = event.payload;
     const { userId } = parseBreadId(breadId);
-
-    console.error('Adapter google admin directory lost');
-    console.error(event);
 
     await adapterCollection().deleteOne({
       userId,

--- a/playground/feat/nav/ui/src/lib/TopNavContainer.tsx
+++ b/playground/feat/nav/ui/src/lib/TopNavContainer.tsx
@@ -4,7 +4,7 @@ export type TopNavContainerProps = PropsWithChildren;
 
 export function TopNavContainer(props: TopNavContainerProps) {
   return (
-    <div className={'h-16 w-screen flex items-center shadow px-8 bg-white'}>
+    <div className={'h-16 w-full flex items-center shadow px-8 bg-white'}>
       {props.children}
     </div>
   );

--- a/playground/feat/people/ui/src/lib/PeopleList.tsx
+++ b/playground/feat/people/ui/src/lib/PeopleList.tsx
@@ -1,6 +1,4 @@
 import type { PersonSchema } from '@easybread/schemas';
-import { Card } from 'playground-ui';
-import Image from 'next/image';
 import { PeopleListItem } from './PeopleListItem';
 
 export type PeopleListProps = {
@@ -11,7 +9,7 @@ export function PeopleList(props: PeopleListProps) {
   const { people } = props;
 
   return (
-    <div className={'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4'}>
+    <div className={'grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4'}>
       {people.map((p) => (
         <PeopleListItem person={p} key={p.identifier} />
       ))}

--- a/playground/ui/src/lib/PageContent/PageContent.tsx
+++ b/playground/ui/src/lib/PageContent/PageContent.tsx
@@ -3,5 +3,5 @@ import type { PropsWithChildren } from 'react';
 export type PageContentProps = PropsWithChildren;
 
 export function PageContent(props: PageContentProps) {
-  return <div className="w-screen flex flex-col px-8">{props.children}</div>;
+  return <div className="w-full flex flex-col px-8">{props.children}</div>;
 }


### PR DESCRIPTION
- slightly improved types in easybread client, service adapter, context, operation, and operation handler
- added an option to define types of service errors
- refactored the BreadOperationContext 
  - do not provide the client in the context
  - simplify type parameters
- filter out non-http exceptions before passing to handler.shouldRetry
- enable inline sourcemaps for jest tests (so that webstorm can debug properly)
- better way of mocking axios in tests
- improvements in some tests
- various minor fixes